### PR TITLE
Added error handling to tracer function

### DIFF
--- a/lib/live_debugger/services/callback_tracer.ex
+++ b/lib/live_debugger/services/callback_tracer.ex
@@ -105,8 +105,13 @@ defmodule LiveDebugger.Services.CallbackTracer do
   defp trace_handler({_, pid, _, {module, function, args}}, n, ets_table_id, recipient_pid) do
     trace = Trace.new(n, module, function, args, pid)
 
-    :ets.insert(ets_table_id, {n, trace})
-    send(recipient_pid, {:new_trace, trace})
+    try do
+      :ets.insert(ets_table_id, {n, trace})
+      send(recipient_pid, {:new_trace, trace})
+    rescue
+      err ->
+        Logger.error("Error while handling trace: #{inspect(err)}")
+    end
 
     n - 1
   end


### PR DESCRIPTION
It is associated with the error below, which sometimes occurs in the dev environment. The reason for it is the incorrect ID of the ets table. I couldn't reproduce it, but I think this error is should be specific to dev env - it is thrown after debugger is recompiled.

For I've added error handling to make sure that traces does not break completely when it occurs, and we'll check if it is present on the prod too

```
** dbg got EXIT - terminating: {trace_handler_crashed,
                            {badarg,

                             [{ets,insert,

                               ['lvdbg-phx-GBkCJ2z39005eQGF',

                                {-15,

                                 #{args =>

                                    [<<"change_name">>,

                                     #{<<"value">> => <<>>},

                                     #{id => <<"phx-GBkCJ2z39005eQGF">>,

                                       private =>

                                        #{lifecycle =>

                                           #{handle_event => [],

                                             handle_info => [],

                                             '__struct__' =>

                                              'Elixir.Phoenix.LiveView.Lifecycle',

                                             mount => [],

                                             handle_async => [],

                                             handle_params => [],

                                             after_render => []},

                                          live_temp => #{},

                                          root_view =>

                                           'Elixir.LiveDebuggerDev.LiveViews.Main',

                                          live_session_vsn =>

                                           1736421499554036947,

                                          live_session_name => default},

                                       '__struct__' =>

                                        'Elixir.Phoenix.LiveView.Socket',

                                       parent_pid => nil,

                                       router =>

                                        'Elixir.LiveDebuggerDev.Router',

                                       assigns =>

                                        #{name => <<"Charlie">>,

                                          counter => 7,flash => #{},

                                          '__changed__' => #{},

                                          live_action => nil,

                                          datetime =>

                                           #{microsecond => {197239,6},

                                             second => 15,

                                             calendar =>

                                              'Elixir.Calendar.ISO',

                                             month => 1,

                                             '__struct__' =>

                                              'Elixir.DateTime',

                                             day => 9,year => 2025,

                                             minute => 20,hour => 11,

                                             time_zone => <<"Etc/UTC">>,

                                             zone_abbr => <<"UTC">>,

                                             utc_offset => 0,

                                             std_offset => 0}},

                                       view =>

                                        'Elixir.LiveDebuggerDev.LiveViews.Main',

                                       endpoint =>

                                        'Elixir.LiveDebuggerDev.Endpoint',

                                       transport_pid => <0.602.0>,

                                       redirected => nil,

                                       root_pid => <0.603.0>,

                                       fingerprints =>

                                        {152977221104626497280800344983402049532,

                                         #{0 =>

                                            {116093646112338848188050896802306988180,

                                             #{}},

                                           1 =>

                                            {30886407565025242608704628507524651515,

                                             #{0 =>

                                                {95551922260049747650004487942996607201,

                                                 #{3 =>

                                                    {108774637945302806352265878543627447858,

                                                     #{}}}},

                                               1 =>

                                                {248686012380780515659975556648703404898,

                                                 #{3 =>

                                                    {188906686981458700719753438376303262310,

                                                     #{}}}}}}}},

                                       host_uri =>

                                        #{port => 4004,

                                          scheme => <<"http">>,

                                          path => nil,

                                          host => <<"localhost">>,

                                          '__struct__' => 'Elixir.URI',

                                          userinfo => nil,fragment => nil,

                                          query => nil,authority => nil}}],

                                   arity => 3,function => handle_event,

                                   id => -15,

                                   module =>

                                    'Elixir.LiveDebuggerDev.LiveViews.Main',

                                   pid => <0.603.0>,

                                   timestamp => 1736421634144995,

                                   '__struct__' =>

                                    'Elixir.LiveDebugger.Structs.Trace',

                                   cid => nil}}],

                               [{error_info,

                                 #{cause => id,

                                   module => erl_stdlib_errors}}]},

                              {'Elixir.LiveDebugger.Services.CallbackTracer',

                               trace_handler,4,

                               [{file,

                                 "lib/live_debugger/services/callback_tracer.ex"},

                                {line,109}]},

                              {dbg,handle_traces,4,

                               [{file,"dbg.erl"},{line,2244}]},

                              {dbg,tracer_loop,2,

                               [{file,"dbg.erl"},{line,2206}]}]}}
```

