### PR TITLE
Bug: Node in components tree take all space when only one

### DIFF
--- a/lib/live_debugger_web/components/tree.ex
+++ b/lib/live_debugger_web/components/tree.ex
@@ -38,14 +38,16 @@ defmodule LiveDebuggerWeb.Components.Tree do
           <.toggle_switch label="Highlight" checked={@highlight?} phx-click="toggle-highlight" />
         <% end %>
       </div>
-      <.tree_node
-        tree_id={@id}
-        tree_node={@tree_node}
-        selected_node_id={@selected_node_id}
-        root?={true}
-        max_opened_node_level={@max_opened_node_level}
-        level={0}
-      />
+      <div class="flex-1">
+        <.tree_node
+          tree_id={@id}
+          tree_node={@tree_node}
+          selected_node_id={@selected_node_id}
+          root?={true}
+          max_opened_node_level={@max_opened_node_level}
+          level={0}
+        />
+      </div>
     </div>
     """
   end


### PR DESCRIPTION
Currently when only 1 element (LiveView) is displayed it takes all the space for ComponentsTree. You can reproduce it on `Side` view in Dev