### PR TITLE
Refactor: Helpers module naming and options

### DIFF
--- a/lib/live_debugger_web/helpers/tracing_helper.ex
+++ b/lib/live_debugger_web/helpers/tracing_helper.ex
@@ -1,4 +1,4 @@
-defmodule LiveDebugger.LiveHelpers.TracingHelper do
+defmodule LiveDebuggerWeb.Helpers.TracingHelper do
   @moduledoc """
   This module provides a helper to manage tracing.
   It is responsible for determining if the tracing should be stopped.

--- a/lib/live_debugger_web/live/traces_live.ex
+++ b/lib/live_debugger_web/live/traces_live.ex
@@ -7,7 +7,7 @@ defmodule LiveDebuggerWeb.TracesLive do
 
   require Logger
 
-  alias LiveDebugger.LiveHelpers.TracingHelper
+  alias LiveDebuggerWeb.Helpers.TracingHelper
   alias LiveDebugger.Services.TraceService
   alias LiveDebugger.Structs.TraceDisplay
   alias LiveDebugger.Utils.PubSub, as: PubSubUtils

--- a/lib/live_debugger_web/router.ex
+++ b/lib/live_debugger_web/router.ex
@@ -1,5 +1,5 @@
 defmodule LiveDebuggerWeb.Router do
-  use Phoenix.Router
+  use Phoenix.Router, helpers: false
 
   import Phoenix.LiveView.Router
 


### PR DESCRIPTION
In this PR the wrong module name is fixed. Also the `helpers: false` option allows to not create `LiveDebuggerWeb.Router.Helpers` since we are using our own helper module