### PR TITLE
Bug: fixed callback tracing after components switching

### DIFF
--- a/lib/live_debugger_web/live/traces_live.ex
+++ b/lib/live_debugger_web/live/traces_live.ex
@@ -243,8 +243,8 @@ defmodule LiveDebuggerWeb.TracesLive do
     default_filters = default_filters(node_id)
 
     socket
-    |> assign(node_id: node_id)
     |> TracingHelper.disable_tracing()
+    |> assign(node_id: node_id)
     |> assign(current_filters: default_filters)
     |> assign(default_filters: default_filters)
     |> assign_async_existing_traces()


### PR DESCRIPTION
Basically when you have callback tracing started and you change debugged node, callbacks from previous component will still appear in the callback traces

Before


https://github.com/user-attachments/assets/a08e1129-393a-4d67-aa96-2ccfe67cc88b



