### PR TITLE
rename node to nodejs in .tool-versions file

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 elixir 1.18.3-otp-27
 erlang 27.1.2
-node 20.17.0
+nodejs 20.17.0


### PR DESCRIPTION
I'm getting this error when runnign `asdf install`:

```bash
asdf install
node plugin is not installed
```

With the change on this PR I'm able to run `asdf install` without any issues:

```bash
asdf install
elixir 1.18.3-otp-27 is already installed
==> Checking whether specified erlang release exists...
==> Downloading 27.1.2 to /Users/joao/.asdf/downloads/erlang/27.1.2/OTP-27.1.2.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 64.1M  100 64.1M    0     0   9.7M      0  0:00:06  0:00:06 --:--:-- 14.6M
==> Copying release into place
Trying to update node-build... ok
To follow progress, use 'tail -f /var/folders/_m/kjk9gfgx59v7wnfwhf8tl1nm0000gn/T/node-build.20250520233937.78777.log' or pass --verbose
Downloading node-v20.17.0-darwin-arm64.tar.gz...
-> https://nodejs.org/dist/v20.17.0/node-v20.17.0-darwin-arm64.tar.gz

WARNING: node-v20.17.0-darwin-arm64 is in LTS Maintenance mode and nearing its end of life.
It only receives *critical* security updates, *critical* bug fixes and documentation updates.

Installing node-v20.17.0-darwin-arm64...
Installed node-v20.17.0-darwin-arm64 to /Users/joao/.asdf/installs/nodejs/20.17.0
```

Is it suppose to work with other tool besides `asdf`?
