### PR TITLE
Backport: Add custom LiveDebugger url config

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ config :live_debugger, :debug_button?, false
 
 # Disables only components highlighting
 config :live_debugger, :highlighting?, false
+
+# Used when LiveDebugger's assets are exposed on other address (e.g. when run inside Docker)
+config :live_debugger, :external_url, "http://localhost:9007"
 ```
 
 ### Content Security Policy

--- a/docs/config.md
+++ b/docs/config.md
@@ -13,6 +13,9 @@ config :live_debugger, :debug_button?, false
 
 # Disables only components highlighting
 config :live_debugger, :highlighting?, false
+
+# Used when LiveDebugger's assets are exposed on other address (e.g. when run inside Docker)
+config :live_debugger, :external_url, "http://localhost:9007"
 ```
 
 ### Content Security Policy

--- a/lib/live_debugger.ex
+++ b/lib/live_debugger.ex
@@ -80,13 +80,14 @@ defmodule LiveDebugger do
   defp put_live_debugger_tags(config) do
     ip_string = config |> Keyword.get(:ip, @default_ip) |> :inet.ntoa() |> List.to_string()
     port = Keyword.get(config, :port, @default_port)
+    live_debugger_url = "http://#{ip_string}:#{port}"
 
     browser_features? = Keyword.get(config, :browser_features?, true)
     debug_button? = Keyword.get(config, :debug_button?, true)
     highlighting? = Keyword.get(config, :highlighting?, true)
+    external_url = Keyword.get(config, :external_url, live_debugger_url)
 
-    live_debugger_url = "http://#{ip_string}:#{port}"
-    live_debugger_assets_url = "http://#{ip_string}:#{port}/#{@assets_path}"
+    live_debugger_assets_url = "#{external_url}/#{@assets_path}"
 
     assigns = %{
       url: live_debugger_url,


### PR DESCRIPTION
* hide behind config option

* change name, update docs

* fix tests