### PR TITLE
Bug: Flaky tests in state server

### DIFF
--- a/test/gen_servers/state_server_test.exs
+++ b/test/gen_servers/state_server_test.exs
@@ -1,5 +1,5 @@
 defmodule LiveDebugger.GenServers.StateServerTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   import Mox
 
@@ -61,6 +61,8 @@ defmodule LiveDebugger.GenServers.StateServerTest do
       StateServer.handle_info({:component_deleted, trace}, [])
 
       assert [{_, ^state}] = :ets.lookup(StateServer.ets_table_name(), inspect(pid))
+
+      :ets.delete(StateServer.ets_table_name())
     end
 
     test "handles render trace and updates state" do
@@ -92,6 +94,8 @@ defmodule LiveDebugger.GenServers.StateServerTest do
       StateServer.handle_info({:render_trace, trace}, [])
 
       assert [{_, ^state}] = :ets.lookup(StateServer.ets_table_name(), inspect(pid))
+
+      :ets.delete(StateServer.ets_table_name())
     end
 
     test "handles dead process status and deletes table record" do
@@ -102,6 +106,8 @@ defmodule LiveDebugger.GenServers.StateServerTest do
       StateServer.handle_info({:process_status, {:dead, pid}}, [])
 
       assert [] = :ets.lookup(StateServer.ets_table_name(), inspect(pid))
+
+      :ets.delete(StateServer.ets_table_name())
     end
   end
 end

--- a/test/gen_servers/state_server_test.exs
+++ b/test/gen_servers/state_server_test.exs
@@ -1,5 +1,5 @@
 defmodule LiveDebugger.GenServers.StateServerTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   import Mox
 


### PR DESCRIPTION
Because there are multiple tests which operate on same name ets table they should be sync. Another approach would be mocking function which returns ets table name but then we would need to expose it (as non-private) and since these tests are small we might not need to do it. 
If you think that it should be mocked I'll change it

@kraleppa @hhubert6 