### PR TITLE
Bug: Wrong color on dark mode fullscreen body

### DIFF
--- a/lib/live_debugger_web/components.ex
+++ b/lib/live_debugger_web/components.ex
@@ -409,7 +409,7 @@ defmodule LiveDebuggerWeb.Components do
           variant="secondary"
         />
       </div>
-      <div class="overflow-auto flex flex-col gap-2 p-2">
+      <div class="overflow-auto flex flex-col gap-2 p-2 text-primary-text">
         <%= render_slot(@inner_block) %>
       </div>
     </dialog>


### PR DESCRIPTION
Before:

<img width="504" alt="image" src="https://github.com/user-attachments/assets/623c8825-1b0f-40e0-9f06-46ecf9814b66" />
