### PR TITLE
Chore: Update firefox extension to meet requirements

### DIFF
--- a/devtools/firefox/manifest.json
+++ b/devtools/firefox/manifest.json
@@ -17,7 +17,8 @@
   },
   "browser_specific_settings": {
     "gecko": {
-      "strict_min_version": "50.0"
+      "id": "@live-debugger-addon-swm",
+      "strict_min_version": "58.0"
     }
   }
 }


### PR DESCRIPTION
The min version must be at least 58.0 due to requirements

<img width="542" alt="Zrzut ekranu 2025-06-11 o 11 24 24" src="https://github.com/user-attachments/assets/e2fc0162-fa57-4185-90d6-35ee08cfb859" />
