### PR TITLE
Refactor: Simplified pubsub routing

### DIFF
--- a/lib/live_debugger/gen_servers/callback_tracing_server.ex
+++ b/lib/live_debugger/gen_servers/callback_tracing_server.ex
@@ -167,7 +167,7 @@ defmodule LiveDebugger.GenServers.CallbackTracingServer do
        when fun in @callback_functions and type in [:return_from, :exception_from] do
     with {call_ts, trace} <- :erlang.get({pid, module, fun}),
          execution_time <- :timer.now_diff(return_ts, call_ts),
-         trace <- %{trace | execution_time: execution_time, exception: type == :exception_from},
+         trace <- %{trace | execution_time: execution_time, type: type},
          :ok <- persist_trace(trace) do
       :erlang.erase({pid, module, fun})
       publish_update_trace(trace)

--- a/lib/live_debugger/gen_servers/callback_tracing_server.ex
+++ b/lib/live_debugger/gen_servers/callback_tracing_server.ex
@@ -222,14 +222,12 @@ defmodule LiveDebugger.GenServers.CallbackTracingServer do
     pid = trace.pid
     node_id = Trace.node_id(trace)
 
-    fun = trace.function
-
     pid
-    |> PubSubUtils.trace_topic_per_node(node_id, fun, :call)
+    |> PubSubUtils.trace_topic(node_id)
     |> PubSubUtils.broadcast({:new_trace, trace})
 
     pid
-    |> PubSubUtils.trace_topic_per_pid(fun, :call)
+    |> PubSubUtils.trace_topic()
     |> PubSubUtils.broadcast({:new_trace, trace})
   end
 
@@ -245,11 +243,11 @@ defmodule LiveDebugger.GenServers.CallbackTracingServer do
     end
 
     pid
-    |> PubSubUtils.trace_topic_per_node(node_id, fun, :return)
+    |> PubSubUtils.trace_topic(node_id)
     |> PubSubUtils.broadcast({:updated_trace, trace})
 
     pid
-    |> PubSubUtils.trace_topic_per_pid(fun, :return)
+    |> PubSubUtils.trace_topic()
     |> PubSubUtils.broadcast({:updated_trace, trace})
   end
 end

--- a/lib/live_debugger/services/trace_service.ex
+++ b/lib/live_debugger/services/trace_service.ex
@@ -108,7 +108,17 @@ defmodule LiveDebugger.Services.TraceService do
           {[ets_elem()], ets_continuation()} | :"$end_of_table"
   defp existing_traces_start(table_id, opts) do
     limit = Keyword.get(opts, :limit, @default_limit)
-    functions = Keyword.get(opts, :functions, [])
+
+    # TODO: Better way to handle this
+    functions =
+      Keyword.get(opts, :functions, [])
+      |> Enum.map(&Atom.to_string/1)
+      |> Enum.map(&String.split(&1, "/"))
+      |> Enum.map(fn [function, arity] ->
+        # TODO: Remove String.to_atom
+        {String.to_atom(function), String.to_integer(arity)}
+      end)
+
     execution_times = Keyword.get(opts, :execution_times, [])
     node_id = Keyword.get(opts, :node_id)
 
@@ -133,30 +143,30 @@ defmodule LiveDebugger.Services.TraceService do
 
   defp match_spec(node_id, functions, execution_times) when is_pid(node_id) do
     [
-      {{:_, %{function: :"$1", execution_time: :"$2", pid: node_id, cid: nil}},
+      {{:_, %{function: :"$1", execution_time: :"$2", arity: :"$3", pid: node_id, cid: nil}},
        to_spec(functions, execution_times), [:"$_"]}
     ]
   end
 
   defp match_spec(%CID{} = node_id, functions, execution_times) do
     [
-      {{:_, %{function: :"$1", execution_time: :"$2", cid: node_id}},
+      {{:_, %{function: :"$1", execution_time: :"$2", arity: :"$3", cid: node_id}},
        to_spec(functions, execution_times), [:"$_"]}
     ]
   end
 
   defp match_spec(nil, functions, execution_times) do
     [
-      {{:_, %{function: :"$1", execution_time: :"$2"}}, to_spec(functions, execution_times),
-       [:"$_"]}
+      {{:_, %{function: :"$1", execution_time: :"$2", arity: :"$3"}},
+       to_spec(functions, execution_times), [:"$_"]}
     ]
   end
 
-  def to_spec(functions, []) do
+  defp to_spec(functions, []) do
     [{:andalso, functions_to_spec(functions), {:"/=", :"$2", nil}}]
   end
 
-  def to_spec(functions, execution_times) do
+  defp to_spec(functions, execution_times) do
     [
       {:andalso,
        {:andalso, functions_to_spec(functions), execution_times_to_spec(execution_times)},
@@ -164,11 +174,13 @@ defmodule LiveDebugger.Services.TraceService do
     ]
   end
 
-  def functions_to_spec([]), do: false
+  defp functions_to_spec([]), do: false
 
-  def functions_to_spec([single]), do: {:"=:=", :"$1", single}
+  defp functions_to_spec([{single_function, arity}]) do
+    {:andalso, {:"=:=", :"$1", single_function}, {:"=:=", :"$3", arity}}
+  end
 
-  def functions_to_spec([first, second | rest]) do
+  defp functions_to_spec([first, second | rest]) do
     initial_orelse =
       {:orelse, functions_to_spec([first]), functions_to_spec([second])}
 
@@ -180,7 +192,7 @@ defmodule LiveDebugger.Services.TraceService do
     {:andalso, result, {:"/=", :"$2", nil}}
   end
 
-  def execution_times_to_spec(execution_times) do
+  defp execution_times_to_spec(execution_times) do
     min_time = Keyword.get(execution_times, :exec_time_min, 0)
     max_time = Keyword.get(execution_times, :exec_time_max, :infinity)
     {:andalso, {:>=, :"$2", min_time}, {:"=<", :"$2", max_time}}

--- a/lib/live_debugger/structs/trace.ex
+++ b/lib/live_debugger/structs/trace.ex
@@ -25,7 +25,7 @@ defmodule LiveDebugger.Structs.Trace do
     :cid,
     :timestamp,
     :execution_time,
-    :exception
+    :type
   ]
 
   @type timestamp() :: {non_neg_integer(), non_neg_integer(), non_neg_integer()}
@@ -42,7 +42,7 @@ defmodule LiveDebugger.Structs.Trace do
           cid: struct() | nil,
           timestamp: integer(),
           execution_time: non_neg_integer() | nil,
-          exception: boolean()
+          type: :call | :return_from | :exception_from
         }
 
   @doc """
@@ -53,7 +53,7 @@ defmodule LiveDebugger.Structs.Trace do
     socket_id = Keyword.get(opts, :socket_id, get_socket_id_from_args(args))
     transport_pid = Keyword.get(opts, :transport_pid, get_transport_pid_from_args(args))
     cid = Keyword.get(opts, :cid, get_cid_from_args(args))
-    exception = Keyword.get(opts, :exception, false)
+    type = Keyword.get(opts, :type, :call)
 
     %__MODULE__{
       id: id,
@@ -67,7 +67,7 @@ defmodule LiveDebugger.Structs.Trace do
       cid: cid,
       timestamp: :timer.now_diff(timestamp, {0, 0, 0}),
       execution_time: nil,
-      exception: exception
+      type: type
     }
   end
 

--- a/lib/live_debugger/utils/pubsub.ex
+++ b/lib/live_debugger/utils/pubsub.ex
@@ -71,23 +71,9 @@ defmodule LiveDebugger.Utils.PubSub do
 
   Use `{:new_trace, trace}` or `{:updated_trace, trace}` for broadcasting.
   """
-  @spec trace_topic_per_node(
-          pid :: pid(),
-          node_id :: TreeNode.id(),
-          fun :: atom(),
-          type :: :call | :return
-        ) :: String.t()
-  def trace_topic_per_node(pid, node_id, fun, type \\ :call) do
-    "#{inspect(pid)}/#{inspect(node_id)}/#{inspect(fun)}/#{inspect(type)}"
-  end
-
-  @spec trace_topic_per_pid(
-          pid :: pid(),
-          fun :: atom(),
-          type :: :call | :return
-        ) :: String.t()
-  def trace_topic_per_pid(pid, fun, type \\ :call) do
-    "#{inspect(pid)}/#{inspect(fun)}/#{inspect(type)}"
+  @spec trace_topic(pid :: pid(), node_id :: TreeNode.id() | nil) :: String.t()
+  def trace_topic(pid, node_id \\ nil) do
+    "#{inspect(pid)}/#{inspect(node_id)}"
   end
 
   @spec impl() :: module()

--- a/lib/live_debugger_web/live/traces/components/filters_fullscreen.ex
+++ b/lib/live_debugger_web/live/traces/components/filters_fullscreen.ex
@@ -126,6 +126,12 @@ defmodule LiveDebuggerWeb.Live.Traces.Components.FiltersFullscreen do
       |> Enum.flat_map(fn {_key, value} -> value end)
       |> Enum.reject(fn {key, _val} -> key in [:min_unit, :max_unit] end)
 
-    Enum.count(flat_current_filters, fn {key, value} -> value != flat_default_filters[key] end)
+    Enum.count(flat_current_filters, fn {key, value} ->
+      value != get_flat_filter(flat_default_filters, key)
+    end)
+  end
+
+  defp get_flat_filter(filters, key) do
+    Enum.find(filters, fn {filter, _value} -> filter == key end) |> elem(1)
   end
 end

--- a/lib/live_debugger_web/live/traces/components/trace.ex
+++ b/lib/live_debugger_web/live/traces/components/trace.ex
@@ -57,7 +57,7 @@ defmodule LiveDebuggerWeb.Live.Traces.Components.Trace do
       class="max-w-full border border-default-border rounded last:mb-4"
       label_class={[
         "font-semibold bg-surface-1-bg p-2 py-3",
-        @trace.exception && "border border-error-icon"
+        @trace.type == :exception_from && "border border-error-icon"
       ]}
       phx-click={if(@render_body?, do: nil, else: "toggle-collapsible")}
       phx-value-trace-id={@trace.id}

--- a/lib/live_debugger_web/live/traces/helpers.ex
+++ b/lib/live_debugger_web/live/traces/helpers.ex
@@ -36,8 +36,8 @@ defmodule LiveDebuggerWeb.Live.Traces.Helpers do
         :live_component -> UtilsCallbacks.live_component_callbacks()
         :global -> UtilsCallbacks.all_callbacks()
       end
-      |> Enum.map(fn {function, _} -> {function, true} end)
-      |> Enum.uniq()
+      # TODO: Remove String.to_atom
+      |> Enum.map(fn {function, arity} -> {String.to_atom("#{function}/#{arity}"), true} end)
 
     %{
       functions: functions,

--- a/lib/live_debugger_web/live/traces/helpers.ex
+++ b/lib/live_debugger_web/live/traces/helpers.ex
@@ -36,17 +36,18 @@ defmodule LiveDebuggerWeb.Live.Traces.Helpers do
         :live_component -> UtilsCallbacks.live_component_callbacks()
         :global -> UtilsCallbacks.all_callbacks()
       end
-      # TODO: Remove String.to_atom
-      |> Enum.map(fn {function, arity} -> {String.to_atom("#{function}/#{arity}"), true} end)
+      |> Enum.reduce(%{}, fn {function, arity}, acc ->
+        Map.put(acc, "#{function}/#{arity}", true)
+      end)
 
     %{
       functions: functions,
-      execution_time: [
-        {:exec_time_max, ""},
-        {:exec_time_min, ""},
-        {:min_unit, Parsers.time_units() |> List.first()},
-        {:max_unit, Parsers.time_units() |> List.first()}
-      ]
+      execution_time: %{
+        "exec_time_max" => "",
+        "exec_time_min" => "",
+        "min_unit" => Parsers.time_units() |> List.first(),
+        "max_unit" => Parsers.time_units() |> List.first()
+      }
     }
   end
 
@@ -72,9 +73,13 @@ defmodule LiveDebuggerWeb.Live.Traces.Helpers do
     |> Enum.map(fn {filter, value} -> {filter, String.to_integer(value)} end)
     |> Enum.map(fn {filter, value} ->
       case filter do
-        :exec_time_min -> {filter, Parsers.time_to_microseconds(value, execution_time[:min_unit])}
-        :exec_time_max -> {filter, Parsers.time_to_microseconds(value, execution_time[:max_unit])}
+        "exec_time_min" ->
+          {filter, Parsers.time_to_microseconds(value, execution_time["min_unit"])}
+
+        "exec_time_max" ->
+          {filter, Parsers.time_to_microseconds(value, execution_time["max_unit"])}
       end
     end)
+    |> Map.new()
   end
 end

--- a/lib/live_debugger_web/live/traces/hooks/filter_traces.ex
+++ b/lib/live_debugger_web/live/traces/hooks/filter_traces.ex
@@ -17,21 +17,25 @@ defmodule LiveDebuggerWeb.Live.Traces.Hooks.FilterTraces do
   end
 
   defp handle_info({:new_trace, trace}, socket) do
-    dbg(socket.assigns.current_filters)
-
-    dbg(trace)
-
-    socket
-    |> halt()
+    if matches_function_filter?(trace, socket.assigns.current_filters) |> dbg() do
+      {:cont, socket}
+    else
+      {:halt, socket}
+    end
   end
 
-  # defp handle_info({:updated_trace, trace}, socket) do
-  #   socket
-  #   |> stream_insert(:existing_traces, trace_display, at: 0, limit: live_stream_limit)
-  #   |> assign(traces_empty?: false)
-  #   |> assign(trace_callback_running?: true)
-  #   |> halt()
-  # end
+  defp handle_info({:updated_trace, trace}, socket) do
+    if matches_function_filter?(trace, socket.assigns.current_filters) do
+      {:cont, socket}
+    else
+      {:halt, socket}
+    end
+  end
 
   defp handle_info(_, socket), do: {:cont, socket}
+
+  defp matches_function_filter?(trace, current_filters) do
+    trace_fa = String.to_atom("#{trace.function}/#{trace.arity}") |> dbg()
+    current_filters.functions[trace_fa]
+  end
 end

--- a/lib/live_debugger_web/live/traces/hooks/filter_traces.ex
+++ b/lib/live_debugger_web/live/traces/hooks/filter_traces.ex
@@ -35,7 +35,6 @@ defmodule LiveDebuggerWeb.Live.Traces.Hooks.FilterTraces do
   defp handle_info(_, socket), do: {:cont, socket}
 
   defp matches_function_filter?(trace, current_filters) do
-    trace_fa = String.to_atom("#{trace.function}/#{trace.arity}")
-    current_filters.functions[trace_fa]
+    current_filters.functions["#{trace.function}/#{trace.arity}"]
   end
 end

--- a/lib/live_debugger_web/live/traces/hooks/filter_traces.ex
+++ b/lib/live_debugger_web/live/traces/hooks/filter_traces.ex
@@ -17,7 +17,7 @@ defmodule LiveDebuggerWeb.Live.Traces.Hooks.FilterTraces do
   end
 
   defp handle_info({:new_trace, trace}, socket) do
-    if matches_function_filter?(trace, socket.assigns.current_filters) |> dbg() do
+    if matches_function_filter?(trace, socket.assigns.current_filters) do
       {:cont, socket}
     else
       {:halt, socket}

--- a/lib/live_debugger_web/live/traces/hooks/filter_traces.ex
+++ b/lib/live_debugger_web/live/traces/hooks/filter_traces.ex
@@ -1,0 +1,37 @@
+defmodule LiveDebuggerWeb.Live.Traces.Hooks.FilterTraces do
+  @moduledoc """
+  This hook is responsible for filtering the traces.
+  """
+
+  use LiveDebuggerWeb, :hook
+
+  @required_assigns [
+    :current_filters
+  ]
+
+  def init(socket) do
+    socket
+    |> check_assigns!(@required_assigns)
+    |> attach_hook(:filter_traces, :handle_info, &handle_info/2)
+    |> register_hook(:filter_traces)
+  end
+
+  defp handle_info({:new_trace, trace}, socket) do
+    dbg(socket.assigns.current_filters)
+
+    dbg(trace)
+
+    socket
+    |> halt()
+  end
+
+  # defp handle_info({:updated_trace, trace}, socket) do
+  #   socket
+  #   |> stream_insert(:existing_traces, trace_display, at: 0, limit: live_stream_limit)
+  #   |> assign(traces_empty?: false)
+  #   |> assign(trace_callback_running?: true)
+  #   |> halt()
+  # end
+
+  defp handle_info(_, socket), do: {:cont, socket}
+end

--- a/lib/live_debugger_web/live/traces/hooks/filter_traces.ex
+++ b/lib/live_debugger_web/live/traces/hooks/filter_traces.ex
@@ -35,7 +35,7 @@ defmodule LiveDebuggerWeb.Live.Traces.Hooks.FilterTraces do
   defp handle_info(_, socket), do: {:cont, socket}
 
   defp matches_function_filter?(trace, current_filters) do
-    trace_fa = String.to_atom("#{trace.function}/#{trace.arity}") |> dbg()
+    trace_fa = String.to_atom("#{trace.function}/#{trace.arity}")
     current_filters.functions[trace_fa]
   end
 end

--- a/lib/live_debugger_web/live/traces/hooks/new_traces.ex
+++ b/lib/live_debugger_web/live/traces/hooks/new_traces.ex
@@ -51,8 +51,8 @@ defmodule LiveDebuggerWeb.Live.Traces.Hooks.NewTraces do
     trace_display = TraceDisplay.from_trace(trace, true)
 
     execution_time = get_execution_times(socket)
-    min_time = Keyword.get(execution_time, :exec_time_min, 0)
-    max_time = Keyword.get(execution_time, :exec_time_max, :infinity)
+    min_time = Map.get(execution_time, "exec_time_min", 0)
+    max_time = Map.get(execution_time, "exec_time_max", :infinity)
 
     if trace.execution_time >= min_time and trace.execution_time <= max_time do
       socket

--- a/lib/live_debugger_web/live/traces/hooks/tracing_fuse.ex
+++ b/lib/live_debugger_web/live/traces/hooks/tracing_fuse.ex
@@ -27,6 +27,7 @@ defmodule LiveDebuggerWeb.Live.Traces.Hooks.TracingFuse do
   @spec init(Phoenix.LiveView.Socket.t()) :: Phoenix.LiveView.Socket.t()
   def init(socket) do
     socket
+    |> check_hook!(:filter_traces)
     |> check_assigns!(@required_assigns)
     |> put_private(:fuse, nil)
     |> attach_hook(:tracing_fuse, :handle_info, &handle_info/2)

--- a/lib/live_debugger_web/live/traces/node_traces_live.ex
+++ b/lib/live_debugger_web/live/traces/node_traces_live.ex
@@ -68,6 +68,7 @@ defmodule LiveDebuggerWeb.Live.Traces.NodeTracesLive do
     |> Components.LoadMoreButton.init(@page_size)
     |> Components.Trace.init()
     |> Components.Stream.init()
+    |> Hooks.FilterTraces.init()
     |> Hooks.TracingFuse.init()
     |> Hooks.ExistingTraces.init(@page_size)
     |> Hooks.NewTraces.init(@live_stream_limit)

--- a/lib/live_debugger_web/live/traces/process_traces_live.ex
+++ b/lib/live_debugger_web/live/traces/process_traces_live.ex
@@ -50,6 +50,7 @@ defmodule LiveDebuggerWeb.Live.Traces.ProcessTracesLive do
     |> Helpers.assign_default_filters()
     |> Helpers.assign_current_filters()
     |> Components.LoadMoreButton.init()
+    |> Hooks.FilterTraces.init()
     |> Hooks.TracingFuse.init()
     |> Hooks.ExistingTraces.init(@page_size)
     |> Hooks.NewTraces.init(@live_stream_limit)

--- a/lib/live_debugger_web/live_components/filters_form.ex
+++ b/lib/live_debugger_web/live_components/filters_form.ex
@@ -176,7 +176,6 @@ defmodule LiveDebuggerWeb.LiveComponents.FiltersForm do
     form =
       functions
       |> Map.merge(execution_time)
-      |> Map.new()
       |> to_form(id: socket.assigns.id)
 
     assign(socket, :form, form)
@@ -185,15 +184,9 @@ defmodule LiveDebuggerWeb.LiveComponents.FiltersForm do
   defp assign_form(socket, filters_map) do
     form = socket.assigns.form
 
-    updated_params =
-      filters_map
-      |> Enum.reduce(%{}, fn {filter, value}, acc ->
-        Map.put(acc, filter, value)
-      end)
-
     form =
       form.params
-      |> Map.merge(updated_params)
+      |> Map.merge(filters_map)
       |> to_form(id: socket.assigns.id)
 
     assign(socket, :form, form)

--- a/lib/live_debugger_web/live_components/filters_form.ex
+++ b/lib/live_debugger_web/live_components/filters_form.ex
@@ -49,12 +49,12 @@ defmodule LiveDebuggerWeb.LiveComponents.FiltersForm do
             target={@myself}
           />
           <div class="flex flex-col gap-3 pl-0.5 pb-4 border-b border-default-border">
+            <%!-- TODO: Remove String.to_atom --%>
             <%= for {function, arity} <- get_callbacks(@node_id) do %>
-              <%= if function == :mount and is_nil(@node_id) do %>
-                <.checkbox field={@form[function]} label="mount/1, mount/3" />
-              <% else %>
-                <.checkbox field={@form[function]} label={"#{function}/#{arity}"} />
-              <% end %>
+              <.checkbox
+                field={@form[String.to_atom("#{function}/#{arity}")]}
+                label={"#{function}/#{arity}"}
+              />
             <% end %>
           </div>
           <.filters_group_header
@@ -206,7 +206,6 @@ defmodule LiveDebuggerWeb.LiveComponents.FiltersForm do
 
   def get_callbacks(nil) do
     UtilsCallbacks.all_callbacks()
-    |> Enum.reject(fn {function, arity} -> function == :mount and arity == 1 end)
   end
 
   def get_callbacks(node_id) do

--- a/test/gen_servers/callback_tracing_server_test.exs
+++ b/test/gen_servers/callback_tracing_server_test.exs
@@ -139,10 +139,10 @@ defmodule LiveDebugger.GenServers.CallbackTracingServerTest do
 
       table = :ets.new(:test_table, [:ordered_set, :public])
 
-      expected_call_topic_per_node = PubSubUtils.trace_topic_per_node(pid, pid, fun, :call)
-      expected_call_topic_per_pid = PubSubUtils.trace_topic_per_pid(pid, fun, :call)
-      expected_return_topic_per_node = PubSubUtils.trace_topic_per_node(pid, pid, fun, :return)
-      expected_return_topic_per_pid = PubSubUtils.trace_topic_per_pid(pid, fun, :return)
+      expected_call_topic_per_node = PubSubUtils.trace_topic(pid, pid)
+      expected_call_topic_per_pid = PubSubUtils.trace_topic(pid)
+      expected_return_topic_per_node = PubSubUtils.trace_topic(pid, pid)
+      expected_return_topic_per_pid = PubSubUtils.trace_topic(pid)
 
       MockEtsTableServer
       |> expect(:table, 2, fn ^pid -> table end)
@@ -209,11 +209,11 @@ defmodule LiveDebugger.GenServers.CallbackTracingServerTest do
 
       table = :ets.new(:test_table, [:ordered_set, :public])
 
-      expected_call_topic_per_node = PubSubUtils.trace_topic_per_node(pid, pid, fun, :call)
-      expected_call_topic_per_pid = PubSubUtils.trace_topic_per_pid(pid, fun, :call)
+      expected_call_topic_per_node = PubSubUtils.trace_topic(pid, pid)
+      expected_call_topic_per_pid = PubSubUtils.trace_topic(pid)
       expected_node_rendered_topic = PubSubUtils.node_rendered_topic()
-      expected_return_topic_per_node = PubSubUtils.trace_topic_per_node(pid, pid, fun, :return)
-      expected_return_topic_per_pid = PubSubUtils.trace_topic_per_pid(pid, fun, :return)
+      expected_return_topic_per_node = PubSubUtils.trace_topic(pid, pid)
+      expected_return_topic_per_pid = PubSubUtils.trace_topic(pid)
 
       MockEtsTableServer
       |> expect(:table, 2, fn ^pid -> table end)

--- a/test/gen_servers/callback_tracing_server_test.exs
+++ b/test/gen_servers/callback_tracing_server_test.exs
@@ -103,7 +103,7 @@ defmodule LiveDebugger.GenServers.CallbackTracingServerTest do
         pid: pid,
         cid: %Phoenix.LiveComponent.CID{cid: cid},
         timestamp: :timer.now_diff(timestamp, {0, 0, 0}),
-        exception: false
+        type: :call
       }
 
       component_deleted_topic =
@@ -189,7 +189,8 @@ defmodule LiveDebugger.GenServers.CallbackTracingServerTest do
 
       expected_execution_time = :timer.now_diff(return_timestamp, call_timestamp)
 
-      assert %{trace | execution_time: expected_execution_time} == updated_trace
+      assert %{trace | execution_time: expected_execution_time, type: :return_from} ==
+               updated_trace
     end
 
     test "handle :render live view trace" do
@@ -244,7 +245,8 @@ defmodule LiveDebugger.GenServers.CallbackTracingServerTest do
                pid: ^pid,
                cid: nil,
                timestamp: ^expected_timestamp,
-               execution_time: nil
+               execution_time: nil,
+               type: :call
              } = trace
 
       return_timestamp = :erlang.timestamp()
@@ -260,7 +262,8 @@ defmodule LiveDebugger.GenServers.CallbackTracingServerTest do
 
       expected_execution_time = :timer.now_diff(return_timestamp, call_timestamp)
 
-      assert %{trace | execution_time: expected_execution_time} == updated_trace
+      assert %{trace | execution_time: expected_execution_time, type: :return_from} ==
+               updated_trace
     end
 
     test "handle unexpected trace" do

--- a/test/gen_servers/callback_tracing_server_test.exs
+++ b/test/gen_servers/callback_tracing_server_test.exs
@@ -141,8 +141,6 @@ defmodule LiveDebugger.GenServers.CallbackTracingServerTest do
 
       expected_call_topic_per_node = PubSubUtils.trace_topic(pid, pid)
       expected_call_topic_per_pid = PubSubUtils.trace_topic(pid)
-      expected_return_topic_per_node = PubSubUtils.trace_topic(pid, pid)
-      expected_return_topic_per_pid = PubSubUtils.trace_topic(pid)
 
       MockEtsTableServer
       |> expect(:table, 2, fn ^pid -> table end)
@@ -150,8 +148,8 @@ defmodule LiveDebugger.GenServers.CallbackTracingServerTest do
       MockPubSubUtils
       |> expect(:broadcast, fn ^expected_call_topic_per_node, {:new_trace, _} -> :ok end)
       |> expect(:broadcast, fn ^expected_call_topic_per_pid, {:new_trace, _} -> :ok end)
-      |> expect(:broadcast, fn ^expected_return_topic_per_node, {:updated_trace, _} -> :ok end)
-      |> expect(:broadcast, fn ^expected_return_topic_per_pid, {:updated_trace, _} -> :ok end)
+      |> expect(:broadcast, fn ^expected_call_topic_per_node, {:updated_trace, _} -> :ok end)
+      |> expect(:broadcast, fn ^expected_call_topic_per_pid, {:updated_trace, _} -> :ok end)
 
       assert {:noreply, %{}} = CallbackTracingServer.handle_info(:setup_tracing, %{})
       assert_receive handle_trace
@@ -212,8 +210,6 @@ defmodule LiveDebugger.GenServers.CallbackTracingServerTest do
       expected_call_topic_per_node = PubSubUtils.trace_topic(pid, pid)
       expected_call_topic_per_pid = PubSubUtils.trace_topic(pid)
       expected_node_rendered_topic = PubSubUtils.node_rendered_topic()
-      expected_return_topic_per_node = PubSubUtils.trace_topic(pid, pid)
-      expected_return_topic_per_pid = PubSubUtils.trace_topic(pid)
 
       MockEtsTableServer
       |> expect(:table, 2, fn ^pid -> table end)
@@ -222,8 +218,8 @@ defmodule LiveDebugger.GenServers.CallbackTracingServerTest do
       |> expect(:broadcast, fn ^expected_call_topic_per_node, {:new_trace, _} -> :ok end)
       |> expect(:broadcast, fn ^expected_call_topic_per_pid, {:new_trace, _} -> :ok end)
       |> expect(:broadcast, fn ^expected_node_rendered_topic, {:render_trace, _} -> :ok end)
-      |> expect(:broadcast, fn ^expected_return_topic_per_node, {:updated_trace, _} -> :ok end)
-      |> expect(:broadcast, fn ^expected_return_topic_per_pid, {:updated_trace, _} -> :ok end)
+      |> expect(:broadcast, fn ^expected_call_topic_per_node, {:updated_trace, _} -> :ok end)
+      |> expect(:broadcast, fn ^expected_call_topic_per_pid, {:updated_trace, _} -> :ok end)
 
       assert {:noreply, %{}} = CallbackTracingServer.handle_info(:setup_tracing, %{})
       assert_receive handle_trace

--- a/test/gen_servers/ets_table_server_test.exs
+++ b/test/gen_servers/ets_table_server_test.exs
@@ -167,7 +167,7 @@ defmodule LiveDebugger.GenServers.EtsTableServerTest do
 
       Process.sleep(100)
 
-      assert 32 == :ets.select_count(ref, [{{:"$1", :"$2"}, [], [true]}])
+      assert 33 == :ets.select_count(ref, [{{:"$1", :"$2"}, [], [true]}])
     end
 
     test "does not trigger when not enough records are in table" do

--- a/test/services/trace_service_test.exs
+++ b/test/services/trace_service_test.exs
@@ -7,7 +7,8 @@ defmodule Services.TraceServiceTest do
   alias LiveDebugger.Services.TraceService
   alias LiveDebugger.MockEtsTableServer
 
-  @all_functions LiveDebugger.Utils.Callbacks.callbacks_functions()
+  @all_functions LiveDebugger.Utils.Callbacks.all_callbacks()
+                 |> Enum.map(fn {function, arity} -> String.to_atom("#{function}/#{arity}") end)
 
   setup :verify_on_exit!
 
@@ -50,8 +51,8 @@ defmodule Services.TraceServiceTest do
 
   describe "existing_traces/2" do
     test "returns traces with default limit", %{module: module, pid: pid, table: table} do
-      trace1 = Fakes.trace(id: 1, module: module, function: :handle_info, pid: pid)
-      trace2 = Fakes.trace(id: 2, module: module, function: :render, pid: pid)
+      trace1 = Fakes.trace(id: 1, module: module, function: :handle_info, arity: 2, pid: pid)
+      trace2 = Fakes.trace(id: 2, module: module, function: :render, arity: 1, pid: pid)
       :ets.insert(table, {trace1.id, trace1})
       :ets.insert(table, {trace2.id, trace2})
 
@@ -63,9 +64,9 @@ defmodule Services.TraceServiceTest do
     end
 
     test "returns traces with limit and continuation", %{module: module, pid: pid, table: table} do
-      trace1 = Fakes.trace(id: 1, module: module, function: :handle_info, pid: pid)
-      trace2 = Fakes.trace(id: 2, module: module, function: :render, pid: pid)
-      trace3 = Fakes.trace(id: 3, module: module, function: :handle_event, pid: pid)
+      trace1 = Fakes.trace(id: 1, module: module, function: :handle_info, arity: 2, pid: pid)
+      trace2 = Fakes.trace(id: 2, module: module, function: :render, arity: 1, pid: pid)
+      trace3 = Fakes.trace(id: 3, module: module, function: :handle_event, arity: 3, pid: pid)
 
       :ets.insert(table, {trace1.id, trace1})
       :ets.insert(table, {trace2.id, trace2})
@@ -90,9 +91,9 @@ defmodule Services.TraceServiceTest do
     end
 
     test "returns traces with functions filter", %{module: module, pid: pid, table: table} do
-      trace1 = Fakes.trace(id: 1, module: module, function: :handle_info, pid: pid)
-      trace2 = Fakes.trace(id: 2, module: module, function: :render, pid: pid)
-      trace3 = Fakes.trace(id: 3, module: module, function: :handle_event, pid: pid)
+      trace1 = Fakes.trace(id: 1, module: module, function: :handle_info, arity: 2, pid: pid)
+      trace2 = Fakes.trace(id: 2, module: module, function: :render, arity: 1, pid: pid)
+      trace3 = Fakes.trace(id: 3, module: module, function: :handle_event, arity: 3, pid: pid)
       :ets.insert(table, {trace1.id, trace1})
       :ets.insert(table, {trace2.id, trace2})
       :ets.insert(table, {trace3.id, trace3})
@@ -100,21 +101,44 @@ defmodule Services.TraceServiceTest do
       MockEtsTableServer
       |> expect(:table, 2, fn ^pid -> table end)
 
-      assert {[^trace1], _} = TraceService.existing_traces(pid, functions: [:handle_info])
+      assert {[^trace1], _} = TraceService.existing_traces(pid, functions: [:"handle_info/2"])
 
       assert {[^trace1, ^trace2], _} =
-               TraceService.existing_traces(pid, functions: [:handle_info, :render, :mount])
+               TraceService.existing_traces(pid,
+                 functions: [:"handle_info/2", :"render/1", :"mount/1"]
+               )
     end
 
     test "returns traces with execution time filter", %{module: module, pid: pid, table: table} do
       trace1 =
-        Fakes.trace(id: 1, module: module, function: :handle_info, pid: pid, execution_time: 11)
+        Fakes.trace(
+          id: 1,
+          module: module,
+          function: :handle_info,
+          arity: 2,
+          pid: pid,
+          execution_time: 11
+        )
 
       trace2 =
-        Fakes.trace(id: 2, module: module, function: :render, pid: pid, execution_time: 25)
+        Fakes.trace(
+          id: 2,
+          module: module,
+          function: :render,
+          arity: 1,
+          pid: pid,
+          execution_time: 25
+        )
 
       trace3 =
-        Fakes.trace(id: 3, module: module, function: :handle_event, pid: pid, execution_time: 100)
+        Fakes.trace(
+          id: 3,
+          module: module,
+          function: :handle_event,
+          arity: 3,
+          pid: pid,
+          execution_time: 100
+        )
 
       :ets.insert(table, {trace1.id, trace1})
       :ets.insert(table, {trace2.id, trace2})
@@ -142,13 +166,34 @@ defmodule Services.TraceServiceTest do
       table: table
     } do
       trace1 =
-        Fakes.trace(id: 1, module: module, function: :handle_info, pid: pid, execution_time: 11)
+        Fakes.trace(
+          id: 1,
+          module: module,
+          function: :handle_info,
+          arity: 2,
+          pid: pid,
+          execution_time: 11
+        )
 
       trace2 =
-        Fakes.trace(id: 2, module: module, function: :render, pid: pid, execution_time: 25)
+        Fakes.trace(
+          id: 2,
+          module: module,
+          function: :render,
+          arity: 1,
+          pid: pid,
+          execution_time: 25
+        )
 
       trace3 =
-        Fakes.trace(id: 3, module: module, function: :handle_event, pid: pid, execution_time: 100)
+        Fakes.trace(
+          id: 3,
+          module: module,
+          function: :handle_event,
+          arity: 3,
+          pid: pid,
+          execution_time: 100
+        )
 
       :ets.insert(table, {trace1.id, trace1})
       :ets.insert(table, {trace2.id, trace2})
@@ -159,18 +204,18 @@ defmodule Services.TraceServiceTest do
 
       assert {[^trace2], _} =
                TraceService.existing_traces(pid,
-                 functions: [:handle_info, :render, :mount],
+                 functions: [:"handle_info/2", :"render/1", :"mount/1"],
                  execution_times: [exec_time_min: 15, exec_time_max: 150]
                )
     end
 
     test "returns traces with node_id filter", %{module: module, pid: pid, table: table} do
       cid = %Phoenix.LiveComponent.CID{cid: 3}
-      trace1 = Fakes.trace(id: 1, module: module, function: :handle_info, pid: pid)
-      trace2 = Fakes.trace(id: 2, module: module, function: :render, pid: pid, cid: cid)
+      trace1 = Fakes.trace(id: 1, module: module, function: :handle_info, arity: 2, pid: pid)
+      trace2 = Fakes.trace(id: 2, module: module, function: :render, arity: 1, pid: pid, cid: cid)
 
       trace3 =
-        Fakes.trace(id: 3, module: module, function: :handle_event, pid: pid, cid: cid)
+        Fakes.trace(id: 3, module: module, function: :handle_event, arity: 3, pid: pid, cid: cid)
 
       :ets.insert(table, {trace1.id, trace1})
       :ets.insert(table, {trace2.id, trace2})
@@ -187,19 +232,20 @@ defmodule Services.TraceServiceTest do
     end
 
     test "returns :end_of_table when no traces match", %{module: module, pid: pid, table: table} do
-      trace1 = Fakes.trace(id: 1, module: module, function: :handle_info, pid: pid)
-      trace2 = Fakes.trace(id: 2, module: module, function: :render, pid: pid)
+      trace1 = Fakes.trace(id: 1, module: module, function: :handle_info, arity: 2, pid: pid)
+      trace2 = Fakes.trace(id: 2, module: module, function: :render, arity: 1, pid: pid)
       :ets.insert(table, {trace1.id, trace1})
       :ets.insert(table, {trace2.id, trace2})
 
       MockEtsTableServer
       |> expect(:table, fn ^pid -> table end)
 
-      assert :end_of_table = TraceService.existing_traces(pid, functions: [:non_existent])
+      assert :end_of_table =
+               TraceService.existing_traces(pid, functions: [:"non_existent/2"])
     end
 
     test "returns only finished traces", %{module: module, pid: pid, table: table} do
-      trace1 = Fakes.trace(id: 1, module: module, function: :handle_info, pid: pid)
+      trace1 = Fakes.trace(id: 1, module: module, function: :handle_info, arity: 2, pid: pid)
 
       trace2 =
         Fakes.trace(id: 2, module: module, function: :render, pid: pid, execution_time: nil)
@@ -218,8 +264,8 @@ defmodule Services.TraceServiceTest do
     test "clears traces for LiveView or LiveComponent", %{module: module, pid: pid, table: table} do
       cid = %Phoenix.LiveComponent.CID{cid: 3}
 
-      trace1 = Fakes.trace(id: 1, module: module, function: :handle_info, pid: pid)
-      trace2 = Fakes.trace(id: 2, module: module, function: :render, pid: pid, cid: cid)
+      trace1 = Fakes.trace(id: 1, module: module, function: :handle_info, arity: 2, pid: pid)
+      trace2 = Fakes.trace(id: 2, module: module, function: :render, arity: 1, pid: pid, cid: cid)
 
       :ets.insert(table, {trace1.id, trace1})
       :ets.insert(table, {trace2.id, trace2})

--- a/test/services/trace_service_test.exs
+++ b/test/services/trace_service_test.exs
@@ -8,7 +8,7 @@ defmodule Services.TraceServiceTest do
   alias LiveDebugger.MockEtsTableServer
 
   @all_functions LiveDebugger.Utils.Callbacks.all_callbacks()
-                 |> Enum.map(fn {function, arity} -> String.to_atom("#{function}/#{arity}") end)
+                 |> Enum.map(fn {function, arity} -> "#{function}/#{arity}" end)
 
   setup :verify_on_exit!
 
@@ -101,11 +101,11 @@ defmodule Services.TraceServiceTest do
       MockEtsTableServer
       |> expect(:table, 2, fn ^pid -> table end)
 
-      assert {[^trace1], _} = TraceService.existing_traces(pid, functions: [:"handle_info/2"])
+      assert {[^trace1], _} = TraceService.existing_traces(pid, functions: ["handle_info/2"])
 
       assert {[^trace1, ^trace2], _} =
                TraceService.existing_traces(pid,
-                 functions: [:"handle_info/2", :"render/1", :"mount/1"]
+                 functions: ["handle_info/2", "render/1", "mount/1"]
                )
     end
 
@@ -149,13 +149,13 @@ defmodule Services.TraceServiceTest do
 
       assert {[^trace2], _} =
                TraceService.existing_traces(pid,
-                 execution_times: [exec_time_min: 15, exec_time_max: 50],
+                 execution_times: %{"exec_time_min" => 15, "exec_time_max" => 50},
                  functions: @all_functions
                )
 
       assert {[^trace2, ^trace3], _} =
                TraceService.existing_traces(pid,
-                 execution_times: [exec_time_min: 15, exec_time_max: :infinity],
+                 execution_times: %{"exec_time_min" => 15, "exec_time_max" => :infinity},
                  functions: @all_functions
                )
     end
@@ -204,8 +204,8 @@ defmodule Services.TraceServiceTest do
 
       assert {[^trace2], _} =
                TraceService.existing_traces(pid,
-                 functions: [:"handle_info/2", :"render/1", :"mount/1"],
-                 execution_times: [exec_time_min: 15, exec_time_max: 150]
+                 functions: ["handle_info/2", "render/1", "mount/1"],
+                 execution_times: %{"exec_time_min" => 15, "exec_time_max" => 150}
                )
     end
 
@@ -241,7 +241,7 @@ defmodule Services.TraceServiceTest do
       |> expect(:table, fn ^pid -> table end)
 
       assert :end_of_table =
-               TraceService.existing_traces(pid, functions: [:"non_existent/2"])
+               TraceService.existing_traces(pid, functions: ["info/2"])
     end
 
     test "returns only finished traces", %{module: module, pid: pid, table: table} do

--- a/test/support/fakes.ex
+++ b/test/support/fakes.ex
@@ -14,7 +14,7 @@ defmodule LiveDebugger.Fakes do
       pid: :c.pid(0, 1, 0),
       timestamp: :erlang.timestamp(),
       execution_time: 1,
-      exception: false
+      type: :call
     ]
 
     fields = Keyword.merge(default, opts)

--- a/test/utils/pubsub_test.exs
+++ b/test/utils/pubsub_test.exs
@@ -20,33 +20,19 @@ defmodule LiveDebugger.Utils.PubSubTest do
     assert "lvdbg/process_status" = PubSubUtils.process_status_topic()
   end
 
-  test "trace_topic_per_node/4" do
+  test "trace_topic/2" do
     pid = :c.pid(0, 1, 0)
     node_id = :c.pid(0, 2, 0)
-    fun = :handle_info
 
-    assert "#PID<0.1.0>/#PID<0.2.0>/:handle_info/:call" =
-             PubSubUtils.trace_topic_per_node(pid, node_id, fun)
-
-    assert "#PID<0.1.0>/#PID<0.2.0>/:handle_info/:call" =
-             PubSubUtils.trace_topic_per_node(pid, node_id, fun, :call)
-
-    assert "#PID<0.1.0>/#PID<0.2.0>/:handle_info/:return" =
-             PubSubUtils.trace_topic_per_node(pid, node_id, fun, :return)
+    assert "#PID<0.1.0>/#PID<0.2.0>" =
+             PubSubUtils.trace_topic(pid, node_id)
   end
 
-  test "trace_topic_per_pid/3" do
+  test "trace_topic/1" do
     pid = :c.pid(0, 1, 0)
-    fun = :handle_info
 
-    assert "#PID<0.1.0>/:handle_info/:call" =
-             PubSubUtils.trace_topic_per_pid(pid, fun)
-
-    assert "#PID<0.1.0>/:handle_info/:call" =
-             PubSubUtils.trace_topic_per_pid(pid, fun, :call)
-
-    assert "#PID<0.1.0>/:handle_info/:return" =
-             PubSubUtils.trace_topic_per_pid(pid, fun, :return)
+    assert "#PID<0.1.0>/nil" =
+             PubSubUtils.trace_topic(pid)
   end
 
   describe "mock" do


### PR DESCRIPTION
From now we filter out everything on the frontend side and we have less pubsub topics