### PR TITLE
Refactor: Add HookComponents for `callback_tracing`

### DIFF
--- a/lib/live_debugger_refactor/app/debugger/callback_tracing/structs/trace_display.ex
+++ b/lib/live_debugger_refactor/app/debugger/callback_tracing/structs/trace_display.ex
@@ -1,4 +1,4 @@
-defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.TraceDisplay do
+defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Structs.TraceDisplay do
   @moduledoc """
   Wrapper for trace to display it in the UI.
 

--- a/lib/live_debugger_refactor/app/debugger/callback_tracing/trace_display.ex
+++ b/lib/live_debugger_refactor/app/debugger/callback_tracing/trace_display.ex
@@ -1,22 +1,27 @@
 defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.TraceDisplay do
   @moduledoc """
   Wrapper for trace to display it in the UI.
+
+  * `id` - id of the trace
+  * `trace` - trace to display
+  * `from_event?` - whether the trace comes from an event
+  * `render_body?` - whether to render the body of the trace
   """
 
   alias LiveDebuggerRefactor.Structs.Trace
 
-  defstruct [:id, :trace, :from_tracing?, :counter, render_body?: false]
+  defstruct [:id, :trace, :from_event?, :counter, render_body?: false]
 
   @type t() :: %__MODULE__{
           id: integer(),
           trace: Trace.t(),
-          from_tracing?: boolean(),
+          from_event?: boolean(),
           render_body?: boolean()
         }
 
-  @spec from_trace(Trace.t(), from_tracing? :: boolean()) :: t()
-  def from_trace(%Trace{} = trace, from_tracing? \\ false) do
-    %__MODULE__{id: trace.id, trace: trace, from_tracing?: from_tracing?}
+  @spec from_trace(Trace.t(), from_event? :: boolean()) :: t()
+  def from_trace(%Trace{} = trace, from_event? \\ false) do
+    %__MODULE__{id: trace.id, trace: trace, from_event?: from_event?}
   end
 
   @spec render_body(t()) :: t()

--- a/lib/live_debugger_refactor/app/debugger/callback_tracing/trace_display.ex
+++ b/lib/live_debugger_refactor/app/debugger/callback_tracing/trace_display.ex
@@ -1,0 +1,26 @@
+defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.TraceDisplay do
+  @moduledoc """
+  Wrapper for trace to display it in the UI.
+  """
+
+  alias LiveDebuggerRefactor.Structs.Trace
+
+  defstruct [:id, :trace, :from_tracing?, :counter, render_body?: false]
+
+  @type t() :: %__MODULE__{
+          id: integer(),
+          trace: Trace.t(),
+          from_tracing?: boolean(),
+          render_body?: boolean()
+        }
+
+  @spec from_trace(Trace.t(), from_tracing? :: boolean()) :: t()
+  def from_trace(%Trace{} = trace, from_tracing? \\ false) do
+    %__MODULE__{id: trace.id, trace: trace, from_tracing?: from_tracing?}
+  end
+
+  @spec render_body(t()) :: t()
+  def render_body(%__MODULE__{} = trace) do
+    Map.put(trace, :render_body?, true)
+  end
+end

--- a/lib/live_debugger_refactor/app/debugger/callback_tracing/trace_display.ex
+++ b/lib/live_debugger_refactor/app/debugger/callback_tracing/trace_display.ex
@@ -2,7 +2,6 @@ defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.TraceDisplay do
   @moduledoc """
   Wrapper for trace to display it in the UI.
 
-  * `id` - id of the trace
   * `trace` - trace to display
   * `from_event?` - whether the trace comes from an event
   * `render_body?` - whether to render the body of the trace
@@ -10,10 +9,9 @@ defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.TraceDisplay do
 
   alias LiveDebuggerRefactor.Structs.Trace
 
-  defstruct [:id, :trace, :from_event?, :counter, render_body?: false]
+  defstruct [:trace, :from_event?, :counter, render_body?: false]
 
   @type t() :: %__MODULE__{
-          id: integer(),
           trace: Trace.t(),
           from_event?: boolean(),
           render_body?: boolean()
@@ -21,7 +19,7 @@ defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.TraceDisplay do
 
   @spec from_trace(Trace.t(), from_event? :: boolean()) :: t()
   def from_trace(%Trace{} = trace, from_event? \\ false) do
-    %__MODULE__{id: trace.id, trace: trace, from_event?: from_event?}
+    %__MODULE__{trace: trace, from_event?: from_event?}
   end
 
   @spec render_body(t()) :: t()

--- a/lib/live_debugger_refactor/app/debugger/callback_tracing/web/components/trace.ex
+++ b/lib/live_debugger_refactor/app/debugger/callback_tracing/web/components/trace.ex
@@ -1,0 +1,128 @@
+defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.Components.Trace do
+  @moduledoc """
+  UI components for the traces.
+  """
+
+  use LiveDebuggerRefactor.App.Web, :component
+
+  alias LiveDebuggerRefactor.App.Debugger.Web.Components.ElixirDisplay
+  alias LiveDebuggerRefactor.App.Debugger.CallbackTracing.TraceDisplay
+  alias LiveDebuggerRefactor.App.Web.Helpers.Routes, as: RoutesHelper
+  alias LiveDebuggerRefactor.App.Utils.Parsers
+  alias LiveDebuggerRefactor.App.Utils.TermParser
+  alias LiveDebuggerRefactor.Structs.Trace
+
+  attr(:id, :string, required: true)
+  attr(:trace, Trace, default: nil)
+
+  def trace_fullscreen(assigns) do
+    assigns =
+      case assigns.trace do
+        nil ->
+          assigns
+          |> assign(:callback_name, "Unknown trace")
+          |> assign(:trace_args, [])
+
+        trace ->
+          assigns
+          |> assign(:callback_name, Trace.callback_name(trace))
+          |> assign(:trace_args, trace.args)
+      end
+
+    ~H"""
+    <.fullscreen id={@id} title={@callback_name}>
+      <div class="w-full flex flex-col gap-4 items-start justify-center hover:[&>div>div>div>button]:hidden">
+        <.trace_body id={@id <> "-fullscreen"} trace={@trace} />
+      </div>
+    </.fullscreen>
+    """
+  end
+
+  attr(:id, :string, required: true)
+  attr(:trace, Trace, required: true)
+
+  def trace_body(assigns) do
+    ~H"""
+    <%= for {args, index} <- Enum.with_index(@trace.args) do %>
+      <div :if={index > 0} class="border-t border-default-border w-full"></div>
+      <div class="flex flex-col gap-4 w-full [&>div>div>button]:hidden hover:[&>div>div>button]:block">
+        <div class="shrink-0 flex gap-2 items-center h-4">
+          <p class="font-semibold">
+            Arg <%= index %> (<%= Trace.arg_name(@trace, index) %>)
+          </p>
+          <.copy_button id={"#{@id}-arg-#{index}"} value={TermParser.term_to_copy_string(args)} />
+        </div>
+        <ElixirDisplay.term
+          id={@id <> "-#{index}"}
+          node={TermParser.term_to_display_tree(args)}
+          level={1}
+        />
+      </div>
+    <% end %>
+    """
+  end
+
+  attr(:trace, Trace, required: true)
+  attr(:class, :string, default: "")
+
+  def module(assigns) do
+    ~H"""
+    <div class={["text-primary text-2xs font-normal truncate", @class]}>
+      <.tooltip id={"#{@trace.id}-trace-module"} content="See in Node Inspector" class="w-max">
+        <.link
+          class="block hover:underline"
+          patch={RoutesHelper.debugger_node_inspector(@trace.pid, @trace.cid)}
+        >
+          <%= Parsers.module_to_string(@trace.module) %>
+          <%= if(@trace.cid, do: "(#{@trace.cid})") %>
+        </.link>
+      </.tooltip>
+    </div>
+    """
+  end
+
+  attr(:trace, Trace, required: true)
+
+  def callback_name(assigns) do
+    assigns = assign(assigns, :content, Trace.callback_name(assigns.trace))
+
+    ~H"""
+    <p class="font-medium text-sm"><%= @content %></p>
+    """
+  end
+
+  attr(:trace_display, TraceDisplay, required: true)
+
+  def trace_time_info(assigns) do
+    ~H"""
+    <div class="flex text-xs font-normal text-secondary-text align-center">
+      <.tooltip id={@trace_display.id <> "-timestamp-tooltip"} content="timestamp" class="min-w-24">
+        <%= Parsers.parse_timestamp(@trace_display.trace.timestamp) %>
+      </.tooltip>
+      <span class="mx-2 border-r border-default-border"></span>
+      <.tooltip
+        id={@trace_display.id <> "-exec-time-tooltip"}
+        content="execution time"
+        class="min-w-11"
+      >
+        <span
+          id={@trace_display.id <> "-exec-time"}
+          class={["text-nowrap", get_threshold_class(@trace_display.trace.execution_time)]}
+          phx-hook={if @trace_display.from_tracing?, do: "TraceExecutionTime"}
+        >
+          <%= Parsers.parse_elapsed_time(@trace_display.trace.execution_time) %>
+        </span>
+      </.tooltip>
+    </div>
+    """
+  end
+
+  defp get_threshold_class(execution_time) do
+    cond do
+      execution_time == nil -> ""
+      execution_time > 500_000 -> "text-error-text"
+      execution_time > 100_000 -> "text-warning-text"
+      true -> ""
+    end
+  end
+end

--- a/lib/live_debugger_refactor/app/debugger/callback_tracing/web/components/trace.ex
+++ b/lib/live_debugger_refactor/app/debugger/callback_tracing/web/components/trace.ex
@@ -60,13 +60,14 @@ defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.Components.Trace
   @doc """
   Module of the trace.
   """
+  attr(:id, :string, required: true)
   attr(:trace, Trace, required: true)
   attr(:class, :string, default: "")
 
   def module(assigns) do
     ~H"""
     <div class={["text-primary text-2xs font-normal truncate", @class]}>
-      <.tooltip id={"#{@trace.id}-trace-module"} content="See in Node Inspector" class="w-max">
+      <.tooltip id={"#{@id}-trace-module"} content="See in Node Inspector" class="w-max">
         <.link
           class="block hover:underline"
           patch={RoutesHelper.debugger_node_inspector(@trace.pid, @trace.cid)}
@@ -95,24 +96,21 @@ defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.Components.Trace
   @doc """
   Timestamp and execution time of the trace.
   """
+  attr(:id, :string, required: true)
   attr(:trace_display, TraceDisplay, required: true)
 
   def trace_time_info(assigns) do
     ~H"""
     <div class="flex text-xs font-normal text-secondary-text align-center">
-      <.tooltip id={@trace_display.id <> "-timestamp-tooltip"} content="timestamp" class="min-w-24">
+      <.tooltip id={@id <> "-timestamp-tooltip"} content="timestamp" class="min-w-24">
         <%= Parsers.parse_timestamp(@trace_display.trace.timestamp) %>
       </.tooltip>
       <span class="mx-2 border-r border-default-border"></span>
-      <.tooltip
-        id={@trace_display.id <> "-exec-time-tooltip"}
-        content="execution time"
-        class="min-w-11"
-      >
+      <.tooltip id={@id <> "-exec-time-tooltip"} content="execution time" class="min-w-11">
         <span
-          id={@trace_display.id <> "-exec-time"}
+          id={@id <> "-exec-time"}
           class={["text-nowrap", get_threshold_class(@trace_display.trace.execution_time)]}
-          phx-hook={if @trace_display.from_tracing?, do: "TraceExecutionTime"}
+          phx-hook={if @trace_display.from_event?, do: "TraceExecutionTime"}
         >
           <%= Parsers.parse_elapsed_time(@trace_display.trace.execution_time) %>
         </span>

--- a/lib/live_debugger_refactor/app/debugger/callback_tracing/web/components/trace.ex
+++ b/lib/live_debugger_refactor/app/debugger/callback_tracing/web/components/trace.ex
@@ -6,7 +6,7 @@ defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.Components.Trace
   use LiveDebuggerRefactor.App.Web, :component
 
   alias LiveDebuggerRefactor.App.Debugger.Web.Components.ElixirDisplay
-  alias LiveDebuggerRefactor.App.Debugger.CallbackTracing.TraceDisplay
+  alias LiveDebuggerRefactor.App.Debugger.CallbackTracing.Structs.TraceDisplay
   alias LiveDebuggerRefactor.App.Web.Helpers.Routes, as: RoutesHelper
   alias LiveDebuggerRefactor.App.Utils.Parsers
   alias LiveDebuggerRefactor.App.Utils.TermParser

--- a/lib/live_debugger_refactor/app/debugger/callback_tracing/web/components/trace.ex
+++ b/lib/live_debugger_refactor/app/debugger/callback_tracing/web/components/trace.ex
@@ -12,22 +12,14 @@ defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.Components.Trace
   alias LiveDebuggerRefactor.App.Utils.TermParser
   alias LiveDebuggerRefactor.Structs.Trace
 
+  @doc """
+  Fullscreen modal with trace body.
+  """
   attr(:id, :string, required: true)
-  attr(:trace, Trace, default: nil)
+  attr(:trace, Trace, required: true)
 
   def trace_fullscreen(assigns) do
-    assigns =
-      case assigns.trace do
-        nil ->
-          assigns
-          |> assign(:callback_name, "Unknown trace")
-          |> assign(:trace_args, [])
-
-        trace ->
-          assigns
-          |> assign(:callback_name, Trace.callback_name(trace))
-          |> assign(:trace_args, trace.args)
-      end
+    assigns = assign(assigns, :callback_name, Trace.callback_name(assigns.trace))
 
     ~H"""
     <.fullscreen id={@id} title={@callback_name}>
@@ -38,6 +30,9 @@ defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.Components.Trace
     """
   end
 
+  @doc """
+  List of trace's args.
+  """
   attr(:id, :string, required: true)
   attr(:trace, Trace, required: true)
 
@@ -62,6 +57,9 @@ defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.Components.Trace
     """
   end
 
+  @doc """
+  Module of the trace.
+  """
   attr(:trace, Trace, required: true)
   attr(:class, :string, default: "")
 
@@ -81,6 +79,9 @@ defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.Components.Trace
     """
   end
 
+  @doc """
+  Callback name of the trace.
+  """
   attr(:trace, Trace, required: true)
 
   def callback_name(assigns) do
@@ -91,6 +92,9 @@ defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.Components.Trace
     """
   end
 
+  @doc """
+  Timestamp and execution time of the trace.
+  """
   attr(:trace_display, TraceDisplay, required: true)
 
   def trace_time_info(assigns) do

--- a/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/clear_button.ex
+++ b/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/clear_button.ex
@@ -1,0 +1,40 @@
+defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.HookComponents.ClearButton do
+  @moduledoc """
+  This component is used to clear the traces.
+  """
+
+  use LiveDebuggerRefactor.App.Web, :hook_component
+
+  @required_assigns [:lv_process, :traces_empty?]
+
+  @impl true
+  def init(socket) do
+    socket
+    |> check_assigns!(@required_assigns)
+    |> check_stream!(:existing_traces)
+    |> attach_hook(:clear_button, :handle_event, &handle_event/3)
+    |> register_hook(:clear_button)
+  end
+
+  attr(:label_class, :string, default: "")
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <.button
+      phx-click="clear-traces"
+      aria-label="Clear traces"
+      class="flex gap-2"
+      variant="secondary"
+      size="sm"
+    >
+      <.icon name="icon-trash" class="w-4 h-4" />
+      <div class={[@label_class, "ml-1"]}>
+        Clear
+      </div>
+    </.button>
+    """
+  end
+
+  defp handle_event(_, _, socket), do: {:cont, socket}
+end

--- a/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/clear_button.ex
+++ b/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/clear_button.ex
@@ -1,6 +1,7 @@
 defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.HookComponents.ClearButton do
   @moduledoc """
   This component is used to clear the traces.
+  It produces `clear-traces` event handled by hook added via `init/1`.
   """
 
   use LiveDebuggerRefactor.App.Web, :hook_component
@@ -36,5 +37,6 @@ defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.HookComponents.C
     """
   end
 
+  defp handle_event("clear-traces", _, socket), do: {:halt, socket}
   defp handle_event(_, _, socket), do: {:cont, socket}
 end

--- a/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/load_more_button.ex
+++ b/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/load_more_button.ex
@@ -1,0 +1,58 @@
+defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.HookComponents.LoadMoreButton do
+  @moduledoc """
+  This component is used to load more traces.
+  It uses `trace_continuation` to determine if there are more traces to load.
+  """
+
+  use LiveDebuggerRefactor.App.Web, :hook_component
+
+  @required_assigns [:lv_process, :traces_continuation, :current_filters]
+
+  @impl true
+  def init(socket) do
+    socket
+    |> check_assigns!(@required_assigns)
+    |> check_stream!(:existing_traces)
+    |> attach_hook(:load_more_button, :handle_event, &handle_event/3)
+    |> register_hook(:load_more_button)
+  end
+
+  attr(:traces_continuation, :any, required: true)
+
+  @impl true
+  def render(%{traces_continuation: nil} = assigns), do: ~H""
+  def render(%{traces_continuation: :end_of_table} = assigns), do: ~H""
+
+  def render(assigns) do
+    ~H"""
+    <div class="flex items-center justify-center">
+      <.content traces_continuation={@traces_continuation} />
+    </div>
+    """
+  end
+
+  defp content(%{traces_continuation: :loading} = assigns) do
+    ~H"""
+    <.spinner size="sm" />
+    """
+  end
+
+  defp content(%{traces_continuation: :error} = assigns) do
+    ~H"""
+    <.alert with_icon={true} heading="Error while loading more traces" class="w-full">
+      Check logs for more details.
+    </.alert>
+    """
+  end
+
+  defp content(%{traces_continuation: cont} = assigns) when is_tuple(cont) do
+    ~H"""
+    <.button phx-click="load-more" class="w-4" variant="secondary">
+      Load more
+    </.button>
+    """
+  end
+
+  defp handle_event("load-more", _, socket), do: {:halt, socket}
+  defp handle_event(_, _, socket), do: {:cont, socket}
+end

--- a/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/load_more_button.ex
+++ b/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/load_more_button.ex
@@ -2,6 +2,7 @@ defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.HookComponents.L
   @moduledoc """
   This component is used to load more traces.
   It uses `trace_continuation` to determine if there are more traces to load.
+  It produces `load-more` event handled by hook added via `init/1`.
   """
 
   use LiveDebuggerRefactor.App.Web, :hook_component

--- a/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/refresh_button.ex
+++ b/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/refresh_button.ex
@@ -1,0 +1,37 @@
+defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.HookComponents.RefreshButton do
+  @moduledoc """
+  This component is used to refresh the traces.
+  """
+
+  use LiveDebuggerRefactor.App.Web, :hook_component
+
+  @impl true
+  def init(socket) do
+    socket
+    |> attach_hook(:refresh_button, :handle_event, &handle_event/3)
+    |> register_hook(:refresh_button)
+  end
+
+  attr(:label_class, :string, default: "")
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <.button
+      phx-click="refresh-history"
+      aria-label="Refresh traces"
+      class="flex gap-2"
+      variant="secondary"
+      size="sm"
+    >
+      <.icon name="icon-refresh" class="w-4 h-4" />
+      <div class={@label_class}>
+        Refresh
+      </div>
+    </.button>
+    """
+  end
+
+  defp handle_event("refresh-history", _, socket), do: {:halt, socket}
+  defp handle_event(_, _, socket), do: {:cont, socket}
+end

--- a/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/refresh_button.ex
+++ b/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/refresh_button.ex
@@ -1,6 +1,7 @@
 defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.HookComponents.RefreshButton do
   @moduledoc """
   This component is used to refresh the traces.
+  It produces `refresh-history` event handled by hook added via `init/1`.
   """
 
   use LiveDebuggerRefactor.App.Web, :hook_component

--- a/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/search_input.ex
+++ b/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/search_input.ex
@@ -1,6 +1,7 @@
 defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.HookComponents.SearchInput do
   @moduledoc """
   This component is used to add filtering by search query for callback traces.
+  It produces `search` and `search-submit` events handled by hook added via `init/1`.
   """
 
   use LiveDebuggerRefactor.App.Web, :hook_component
@@ -27,7 +28,7 @@ defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.HookComponents.S
       "has-[input:focus-within]:outline-2 has-[input:focus-within]:-outline-offset-2",
       "outline-default-border has-[input:focus-within]:outline-ui-accent"
     ]}>
-      <form phx-change="search" phx-submit="submit" class="flex items-center w-full h-full">
+      <form phx-change="search" phx-submit="search-submit" class="flex items-center w-full h-full">
         <.icon
           name="icon-search"
           class={[
@@ -51,6 +52,6 @@ defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.HookComponents.S
   end
 
   defp handle_event("search", _params, socket), do: {:halt, socket}
-  defp handle_event("submit", _params, socket), do: {:halt, socket}
+  defp handle_event("search-submit", _params, socket), do: {:halt, socket}
   defp handle_event(_, _, socket), do: {:cont, socket}
 end

--- a/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/search_input.ex
+++ b/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/search_input.ex
@@ -1,0 +1,56 @@
+defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.HookComponents.SearchInput do
+  @moduledoc """
+  This component is used to add filtering by search query for callback traces.
+  """
+
+  use LiveDebuggerRefactor.App.Web, :hook_component
+
+  @required_assigns [:trace_search_query]
+
+  @impl true
+  def init(socket) do
+    socket
+    |> check_assigns!(@required_assigns)
+    |> attach_hook(:search_input, :handle_event, &handle_event/3)
+    |> register_hook(:search_input)
+  end
+
+  attr(:placeholder, :string, default: "Search...")
+  attr(:disabled?, :boolean, default: false)
+  attr(:trace_search_query, :string, default: "", doc: "The current search query for traces")
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class={[
+      "flex shrink items-center rounded-[7px] outline outline-1 -outline-offset-1",
+      "has-[input:focus-within]:outline-2 has-[input:focus-within]:-outline-offset-2",
+      "outline-default-border has-[input:focus-within]:outline-ui-accent"
+    ]}>
+      <form phx-change="search" phx-submit="submit" class="flex items-center w-full h-full">
+        <.icon
+          name="icon-search"
+          class={[
+            "h-4 w-4 ml-3",
+            (@disabled? && "text-gray-400") || "text-primary-icon"
+          ]}
+        />
+        <input
+          disabled={@disabled?}
+          id="trace-search-input"
+          placeholder={@placeholder}
+          value={@trace_search_query}
+          type="text"
+          name="search_query"
+          class="block remove-arrow w-16 sm:w-64  min-w-32 bg-surface-0-bg border-none py-2.5 pl-2 pr-3 text-xs text-primary-text placeholder:text-ui-muted focus:ring-0 disabled:!text-gray-500 disabled:placeholder-grey-300
+          "
+        />
+      </form>
+    </div>
+    """
+  end
+
+  defp handle_event("search", _params, socket), do: {:halt, socket}
+  defp handle_event("submit", _params, socket), do: {:halt, socket}
+  defp handle_event(_, _, socket), do: {:cont, socket}
+end

--- a/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/toggle_tracing_button.ex
+++ b/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/toggle_tracing_button.ex
@@ -1,0 +1,38 @@
+defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.HookComponents.ToggleTracingButton do
+  @moduledoc """
+  This component is responsible for the toggle tracing button.
+  """
+
+  use LiveDebuggerRefactor.App.Web, :hook_component
+
+  @required_assigns [:tracing_started?, :traces_empty?]
+
+  @impl true
+  def init(socket) do
+    socket
+    |> check_assigns!(@required_assigns)
+    |> attach_hook(:toggle_tracing_button, :handle_event, &handle_event/3)
+    |> register_hook(:toggle_tracing_button)
+  end
+
+  attr(:tracing_started?, :boolean, required: true)
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <.button phx-click="switch-tracing" class="flex gap-2" size="sm">
+      <div class="flex gap-1.5 items-center w-12">
+        <%= if @tracing_started? do %>
+          <.icon name="icon-stop" class="w-4 h-4" />
+          <div>Stop</div>
+        <% else %>
+          <.icon name="icon-play" class="w-3.5 h-3.5" />
+          <div>Start</div>
+        <% end %>
+      </div>
+    </.button>
+    """
+  end
+
+  defp handle_event(_, _, socket), do: {:cont, socket}
+end

--- a/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/toggle_tracing_button.ex
+++ b/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/toggle_tracing_button.ex
@@ -34,5 +34,6 @@ defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.HookComponents.T
     """
   end
 
+  defp handle_event("switch-tracing", _, socket), do: {:halt, socket}
   defp handle_event(_, _, socket), do: {:cont, socket}
 end

--- a/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/trace_wrapper.ex
+++ b/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/trace_wrapper.ex
@@ -19,7 +19,7 @@ defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.HookComponents.T
 
   use LiveDebuggerRefactor.App.Web, :hook_component
 
-  alias LiveDebuggerRefactor.App.Debugger.CallbackTracing.TraceDisplay
+  alias LiveDebuggerRefactor.App.Debugger.CallbackTracing.Structs.TraceDisplay
 
   @impl true
   def init(socket) do

--- a/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/trace_wrapper.ex
+++ b/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/trace_wrapper.ex
@@ -1,0 +1,90 @@
+defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.HookComponents.TraceWrapper do
+  @moduledoc """
+  Collapsible trace wrapper.
+  It produces `open_trace` and `toggle_collapsible` events handled by hooks added via `init/1`.
+
+  Use `LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.Components.Trace` to compose the label of the trace.
+
+  ## Examples
+
+      <TraceWrapper.render id="trace-1" trace_display={@trace_display}>
+        <:label class="grid-cols-[auto]">
+          Trace Label
+        </:label>
+        <:body>
+          Trace Body
+        </:body>
+      </TraceWrapper.render>
+  """
+
+  use LiveDebuggerRefactor.App.Web, :hook_component
+
+  alias LiveDebuggerRefactor.App.Debugger.CallbackTracing.TraceDisplay
+
+  @impl true
+  def init(socket) do
+    socket
+    |> attach_hook(:trace, :handle_event, &handle_event/3)
+    |> register_hook(:trace)
+  end
+
+  attr(:id, :string, required: true)
+  attr(:trace_display, TraceDisplay, required: true)
+
+  slot(:body, required: true)
+
+  slot :label, required: true do
+    attr(:class, :string, doc: "Additional class for label")
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <.collapsible
+      id={@id}
+      icon="icon-chevron-right"
+      chevron_class="w-5 h-5 text-accent-icon"
+      class="max-w-full border border-default-border rounded last:mb-4"
+      label_class={[
+        "font-semibold bg-surface-1-bg p-2 py-3",
+        @trace.type == :exception_from && "border border-error-icon"
+      ]}
+      phx-click={if(@render_body?, do: nil, else: "toggle-collapsible")}
+      phx-value-trace-id={@trace.id}
+    >
+      <:label>
+        <div
+          :for={label <- @label}
+          id={@id <> "-label"}
+          class={["w-[90%] grow grid items-center gap-x-3 ml-2" | List.wrap(label[:class])]}
+        >
+          <%= render_slot(label, assigns.trace_display) %>
+        </div>
+      </:label>
+      <div class="relative">
+        <div :if={@render_body?} class="absolute right-0 top-0 z-10">
+          <.fullscreen_button
+            id={"trace-fullscreen-#{@id}"}
+            class="m-2"
+            phx-click="open-trace"
+            phx-value-data={@trace.id}
+          />
+        </div>
+        <div class="flex flex-col gap-4 overflow-x-auto max-w-full max-h-[30vh] overflow-y-auto p-4">
+          <%= if @render_body? do %>
+            <%= render_slot(@body) %>
+          <% else %>
+            <div class="w-full flex items-center justify-center">
+              <.spinner size="sm" />
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </.collapsible>
+    """
+  end
+
+  defp handle_event("open-trace", _, socket), do: {:halt, socket}
+  defp handle_event("toggle-collapsible", _, socket), do: {:halt, socket}
+  defp handle_event(_, _, socket), do: {:cont, socket}
+end

--- a/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/trace_wrapper.ex
+++ b/lib/live_debugger_refactor/app/debugger/callback_tracing/web/hook_components/trace_wrapper.ex
@@ -39,6 +39,13 @@ defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.HookComponents.T
 
   @impl true
   def render(assigns) do
+    assigns =
+      assign(
+        assigns,
+        render_body?: assigns.trace_display.render_body?,
+        trace: assigns.trace_display.trace
+      )
+
     ~H"""
     <.collapsible
       id={@id}
@@ -58,7 +65,7 @@ defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Web.HookComponents.T
           id={@id <> "-label"}
           class={["w-[90%] grow grid items-center gap-x-3 ml-2" | List.wrap(label[:class])]}
         >
-          <%= render_slot(label, assigns.trace_display) %>
+          <%= render_slot(label) %>
         </div>
       </:label>
       <div class="relative">

--- a/lib/live_debugger_refactor/app/debugger/components_tree/web/components.ex
+++ b/lib/live_debugger_refactor/app/debugger/components_tree/web/components.ex
@@ -5,7 +5,7 @@ defmodule LiveDebuggerRefactor.App.Debugger.ComponentsTree.Web.Components do
 
   use LiveDebuggerRefactor.App.Web, :component
 
-  alias LiveDebuggerRefactor.App.Debugger.TreeNode
+  alias LiveDebuggerRefactor.App.Debugger.Structs.TreeNode
   alias LiveDebuggerRefactor.App.Utils.Parsers
 
   @doc """

--- a/lib/live_debugger_refactor/app/debugger/components_tree/web/components.ex
+++ b/lib/live_debugger_refactor/app/debugger/components_tree/web/components.ex
@@ -129,7 +129,7 @@ defmodule LiveDebuggerRefactor.App.Debugger.ComponentsTree.Web.Components do
         class="flex min-w-0 gap-1 items-center"
       >
         <.icon name={@icon} class="text-accent-icon w-4 h-4 shrink-0" />
-        <.tooltip id={"tooltip-#{@id}"} content={@tooltip_content} class="truncate">
+        <.tooltip id={@id <> "-tooltip"} content={@tooltip_content} class="truncate">
           <span class={["hover:underline", if(@selected?, do: "font-semibold")]}>
             <%= @label %>
           </span>

--- a/lib/live_debugger_refactor/app/debugger/components_tree/web/components_tree_live.ex
+++ b/lib/live_debugger_refactor/app/debugger/components_tree/web/components_tree_live.ex
@@ -25,7 +25,7 @@ defmodule LiveDebuggerRefactor.App.Debugger.ComponentsTree.Web.ComponentsTreeLiv
   @impl true
   def mount(_params, _session, socket) do
     # Dummy data
-    dummy_node = %LiveDebuggerRefactor.App.Debugger.TreeNode{
+    dummy_node = %LiveDebuggerRefactor.App.Debugger.Structs.TreeNode{
       id: :c.pid(0, 123, 0),
       type: :live_view,
       module: LiveDebuggerRefactor.App.Settings.Web.SettingsLive,

--- a/lib/live_debugger_refactor/app/debugger/structs/tree_node.ex
+++ b/lib/live_debugger_refactor/app/debugger/structs/tree_node.ex
@@ -1,4 +1,4 @@
-defmodule LiveDebuggerRefactor.App.Debugger.TreeNode do
+defmodule LiveDebuggerRefactor.App.Debugger.Structs.TreeNode do
   @moduledoc """
   Structs and functions to build and manipulate the tree of LiveView and LiveComponent nodes.
   """

--- a/lib/live_debugger_refactor/app/utils/parsers.ex
+++ b/lib/live_debugger_refactor/app/utils/parsers.ex
@@ -1,8 +1,56 @@
 defmodule LiveDebuggerRefactor.App.Utils.Parsers do
   @moduledoc """
-  Utility functions to parse and convert data types to string representations and vice versa.
+  Utilities to parse and convert data types.
   """
+
   alias LiveDebuggerRefactor.CommonTypes
+
+  @time_units ["µs", "ms", "s"]
+
+  @spec time_units() :: [String.t()]
+  def time_units(), do: @time_units
+
+  @doc """
+  Parses a unix timestamp in microseconds to a string representation of the timestamp.
+
+  ## Examples
+
+      iex> LiveDebuggerRefactor.App.Utils.Parsers.parse_timestamp(1_000_000)
+      "00:00:01.000000"
+  """
+  @spec parse_timestamp(non_neg_integer()) :: String.t()
+  def parse_timestamp(timestamp) when is_integer(timestamp) and timestamp > 0 do
+    timestamp
+    |> DateTime.from_unix(:microsecond)
+    |> case do
+      {:ok, %DateTime{hour: hour, minute: minute, second: second, microsecond: {micro, _}}} ->
+        "~2..0B:~2..0B:~2..0B.~6..0B"
+        |> :io_lib.format([hour, minute, second, micro])
+        |> IO.iodata_to_binary()
+
+      _ ->
+        "Invalid timestamp"
+    end
+  end
+
+  @doc """
+  Parses a microseconds to a string representation of the elapsed time.
+
+  ## Examples
+
+      iex> LiveDebuggerRefactor.App.Utils.Parsers.parse_elapsed_time(1_000)
+      "1 ms"
+  """
+  @spec parse_elapsed_time(non_neg_integer() | nil) :: String.t()
+  def parse_elapsed_time(nil), do: ""
+
+  def parse_elapsed_time(microseconds) do
+    cond do
+      microseconds < 1_000 -> "#{microseconds} µs"
+      microseconds < 1_000_000 -> "#{div(microseconds, 1_000)} ms"
+      true -> "#{:io_lib.format("~.2f", [microseconds / 1_000_000])} s"
+    end
+  end
 
   @doc """
   Converts PID to string representation (`"0.123.0"`).

--- a/lib/live_debugger_refactor/app/web.ex
+++ b/lib/live_debugger_refactor/app/web.ex
@@ -72,5 +72,6 @@ defmodule LiveDebuggerRefactor.App.Web do
     """
 
     @callback init(Phoenix.LiveView.Socket.t()) :: Phoenix.LiveView.Socket.t()
+    @callback render(assigns :: map()) :: Phoenix.LiveView.Rendered.t()
   end
 end

--- a/lib/live_debugger_refactor/app/web/components.ex
+++ b/lib/live_debugger_refactor/app/web/components.ex
@@ -539,7 +539,7 @@ defmodule LiveDebuggerRefactor.App.Web.Components do
   @doc """
   Renders a tooltip using Tooltip hook.
   """
-  attr(:id, :string, required: true, doc: "ID of the tooltip. Prefix is added automatically.")
+  attr(:id, :string, required: true, doc: "ID of the tooltip.")
   attr(:content, :string, default: nil)
 
   attr(:position, :string,
@@ -625,9 +625,9 @@ defmodule LiveDebuggerRefactor.App.Web.Components do
 
   def copy_button(assigns) do
     ~H"""
-    <.tooltip id={@id} content="Copy" position="top-center">
+    <.tooltip id={@id <> "-tooltip"} content="Copy" position="top-center">
       <.icon_button
-        id={"copy-button_" <> @id}
+        id={@id}
         icon="icon-copy"
         variant="secondary"
         class={

--- a/lib/live_debugger_refactor/structs/trace.ex
+++ b/lib/live_debugger_refactor/structs/trace.ex
@@ -94,53 +94,53 @@ defmodule LiveDebuggerRefactor.Structs.Trace do
   def live_component_delete?(_), do: false
 
   @spec callback_name(t()) :: String.t()
-  def callback_name(trace) do
-    "#{trace.function}/#{trace.arity}"
+  def callback_name(%__MODULE__{function: function, arity: arity}) do
+    "#{function}/#{arity}"
   end
 
   @spec arg_name(t(), non_neg_integer()) :: String.t()
   def arg_name(trace, arg_index)
 
   # Callbacks common for LiveView and LiveComponent
-  def arg_name(%{function: :handle_async}, 0), do: "name"
-  def arg_name(%{function: :handle_async}, 1), do: "async_fun_result"
-  def arg_name(%{function: :handle_async}, 2), do: "socket"
+  def arg_name(%__MODULE__{function: :handle_async}, 0), do: "name"
+  def arg_name(%__MODULE__{function: :handle_async}, 1), do: "async_fun_result"
+  def arg_name(%__MODULE__{function: :handle_async}, 2), do: "socket"
 
-  def arg_name(%{function: :handle_call}, 0), do: "message"
-  def arg_name(%{function: :handle_call}, 1), do: "from"
-  def arg_name(%{function: :handle_call}, 2), do: "socket"
+  def arg_name(%__MODULE__{function: :handle_call}, 0), do: "message"
+  def arg_name(%__MODULE__{function: :handle_call}, 1), do: "from"
+  def arg_name(%__MODULE__{function: :handle_call}, 2), do: "socket"
 
-  def arg_name(%{function: :handle_cast}, 0), do: "message"
-  def arg_name(%{function: :handle_cast}, 1), do: "socket"
+  def arg_name(%__MODULE__{function: :handle_cast}, 0), do: "message"
+  def arg_name(%__MODULE__{function: :handle_cast}, 1), do: "socket"
 
-  def arg_name(%{function: :handle_event}, 0), do: "event"
-  def arg_name(%{function: :handle_event}, 1), do: "unsigned_params"
-  def arg_name(%{function: :handle_event}, 2), do: "socket"
+  def arg_name(%__MODULE__{function: :handle_event}, 0), do: "event"
+  def arg_name(%__MODULE__{function: :handle_event}, 1), do: "unsigned_params"
+  def arg_name(%__MODULE__{function: :handle_event}, 2), do: "socket"
 
-  def arg_name(%{function: :handle_info}, 0), do: "message"
-  def arg_name(%{function: :handle_info}, 1), do: "socket"
+  def arg_name(%__MODULE__{function: :handle_info}, 0), do: "message"
+  def arg_name(%__MODULE__{function: :handle_info}, 1), do: "socket"
 
-  def arg_name(%{function: :handle_params}, 0), do: "unsigned_params"
-  def arg_name(%{function: :handle_params}, 1), do: "uri"
-  def arg_name(%{function: :handle_params}, 2), do: "socket"
+  def arg_name(%__MODULE__{function: :handle_params}, 0), do: "unsigned_params"
+  def arg_name(%__MODULE__{function: :handle_params}, 1), do: "uri"
+  def arg_name(%__MODULE__{function: :handle_params}, 2), do: "socket"
 
-  def arg_name(%{function: :render}, 0), do: "assigns"
+  def arg_name(%__MODULE__{function: :render}, 0), do: "assigns"
 
-  def arg_name(%{function: :terminate}, 0), do: "reason"
-  def arg_name(%{function: :terminate}, 1), do: "socket"
+  def arg_name(%__MODULE__{function: :terminate}, 0), do: "reason"
+  def arg_name(%__MODULE__{function: :terminate}, 1), do: "socket"
 
   # LiveView specific
-  def arg_name(%{function: :mount, arity: 3}, 0), do: "params"
-  def arg_name(%{function: :mount, arity: 3}, 1), do: "session"
-  def arg_name(%{function: :mount, arity: 3}, 2), do: "socket"
+  def arg_name(%__MODULE__{function: :mount, arity: 3}, 0), do: "params"
+  def arg_name(%__MODULE__{function: :mount, arity: 3}, 1), do: "session"
+  def arg_name(%__MODULE__{function: :mount, arity: 3}, 2), do: "socket"
 
   # LiveComponent specific
-  def arg_name(%{function: :mount, arity: 1}, 0), do: "socket"
+  def arg_name(%__MODULE__{function: :mount, arity: 1}, 0), do: "socket"
 
-  def arg_name(%{function: :update}, 0), do: "assigns"
-  def arg_name(%{function: :update}, 1), do: "socket"
+  def arg_name(%__MODULE__{function: :update}, 0), do: "assigns"
+  def arg_name(%__MODULE__{function: :update}, 1), do: "socket"
 
-  def arg_name(%{function: :update_many}, 0), do: "list"
+  def arg_name(%__MODULE__{function: :update_many}, 0), do: "list"
 
   defp get_transport_pid_from_args(args) do
     args

--- a/test/live_debugger_refactor/app/debugger/callback_tracing/structs/trace_display_test.exs
+++ b/test/live_debugger_refactor/app/debugger/callback_tracing/structs/trace_display_test.exs
@@ -1,0 +1,27 @@
+defmodule LiveDebuggerRefactor.App.Debugger.CallbackTracing.Structs.TraceDisplayTest do
+  use ExUnit.Case, async: true
+
+  alias LiveDebuggerRefactor.App.Debugger.CallbackTracing.Structs.TraceDisplay
+  alias LiveDebuggerRefactor.Fakes
+
+  test "from_trace/1 creates a TraceDisplay struct" do
+    trace = Fakes.trace()
+    trace_display = TraceDisplay.from_trace(trace)
+
+    assert %TraceDisplay{trace: ^trace, from_event?: false, render_body?: false} = trace_display
+  end
+
+  test "from_trace/2 creates a TraceDisplay struct with proper from_event? value" do
+    trace = Fakes.trace()
+    trace_display = TraceDisplay.from_trace(trace, true)
+
+    assert %TraceDisplay{trace: ^trace, from_event?: true, render_body?: false} = trace_display
+  end
+
+  test "render_body/1 sets render_body? to true" do
+    trace_display = %TraceDisplay{trace: Fakes.trace(), from_event?: false, render_body?: false}
+    updated_trace_display = TraceDisplay.render_body(trace_display)
+
+    assert %TraceDisplay{render_body?: true} = updated_trace_display
+  end
+end

--- a/test/live_debugger_refactor/app/debugger/structs/tree_node_test.exs
+++ b/test/live_debugger_refactor/app/debugger/structs/tree_node_test.exs
@@ -1,8 +1,8 @@
-defmodule LiveDebuggerRefactor.App.Debugger.TreeNodeTest do
+defmodule LiveDebuggerRefactor.App.Debugger.Structs.TreeNodeTest do
   use ExUnit.Case, async: true
 
   alias LiveDebuggerRefactor.Fakes
-  alias LiveDebuggerRefactor.App.Debugger.TreeNode
+  alias LiveDebuggerRefactor.App.Debugger.Structs.TreeNode
 
   describe "parse_id/1" do
     test "parses id for LiveView" do

--- a/test/live_debugger_refactor/app/utils/parsers_test.exs
+++ b/test/live_debugger_refactor/app/utils/parsers_test.exs
@@ -3,6 +3,35 @@ defmodule LiveDebuggerRefactor.App.Utils.ParsersTest do
 
   alias LiveDebuggerRefactor.App.Utils.Parsers
 
+  describe "parse_timestamp/1" do
+    test "parses a valid timestamp" do
+      timestamp1 = 1_000_000
+      assert Parsers.parse_timestamp(timestamp1) == "00:00:01.000000"
+
+      timestamp2 = 60_000_000
+      assert Parsers.parse_timestamp(timestamp2) == "00:01:00.000000"
+    end
+
+    test "returns \"Invalid timestamp\" when timestamp is invalid" do
+      timestamp = 109_201_930_129_391_238_012_983_091_283_712_097_380_127
+      assert Parsers.parse_timestamp(timestamp) == "Invalid timestamp"
+    end
+  end
+
+  describe "parse_elapsed_time/1" do
+    test "parses microseconds for less than 1ms" do
+      assert Parsers.parse_elapsed_time(500) == "500 µs"
+    end
+
+    test "parses milliseconds" do
+      assert Parsers.parse_elapsed_time(1_500) == "1 ms"
+    end
+
+    test "parses seconds" do
+      assert Parsers.parse_elapsed_time(1_500_000) == "1.50 s"
+    end
+  end
+
   test "pid_to_string/1 converts pid to string" do
     pid = :c.pid(0, 123, 0)
     assert Parsers.pid_to_string(pid) == "0.123.0"

--- a/test/live_debugger_refactor/support/fakes.ex
+++ b/test/live_debugger_refactor/support/fakes.ex
@@ -17,7 +17,7 @@ defmodule LiveDebuggerRefactor.Fakes do
     ]
 
     Kernel.struct!(
-      LiveDebuggerRefactor.App.Debugger.TreeNode,
+      LiveDebuggerRefactor.App.Debugger.Structs.TreeNode,
       Keyword.merge(default, opts)
     )
   end
@@ -36,7 +36,7 @@ defmodule LiveDebuggerRefactor.Fakes do
     ]
 
     Kernel.struct!(
-      LiveDebuggerRefactor.App.Debugger.TreeNode,
+      LiveDebuggerRefactor.App.Debugger.Structs.TreeNode,
       Keyword.merge(default, opts)
     )
   end


### PR DESCRIPTION
I've added behaviour for HookComponents, and moved the components to compose a trace into `Components`. Filters will be done in other PR since this one is already big enough