### PR TITLE
Enhancement: Event struct

### DIFF
--- a/lib/live_debugger/event.ex
+++ b/lib/live_debugger/event.ex
@@ -56,7 +56,7 @@ defmodule LiveDebugger.Event do
   """
   @type t :: %{
           :__struct__ => atom(),
-          :__event__ => nil,
+          :__event__ => true,
           optional(atom()) => any()
         }
 


### PR DESCRIPTION
Currently there was warning with `Event.t()` because it had `context` in it. The `__event__` field might be useful to differentiate it from other structs (but I can delete it)