### PR TITLE
Refactor: Change components to better match designs

### DIFF
--- a/lib/live_debugger/app/debugger/callback_tracing/web/components/trace.ex
+++ b/lib/live_debugger/app/debugger/callback_tracing/web/components/trace.ex
@@ -24,7 +24,7 @@ defmodule LiveDebugger.App.Debugger.CallbackTracing.Web.Components.Trace do
 
     ~H"""
     <.fullscreen id={@id} title={@callback_name}>
-      <div class="w-full flex flex-col gap-4 items-start justify-center hover:[&>div>div>div>button]:hidden">
+      <div class="p-4 flex flex-col gap-4 items-start justify-center hover:[&>div>div>div>button]:hidden">
         <.trace_body id={@id <> "-fullscreen"} trace={@trace} {@rest} />
       </div>
     </.fullscreen>
@@ -40,7 +40,7 @@ defmodule LiveDebugger.App.Debugger.CallbackTracing.Web.Components.Trace do
 
   def trace_body(assigns) do
     ~H"""
-    <div id={@id <> "-body"} class="flex flex-col gap-4" {@rest}>
+    <div id={@id <> "-body"} class="flex flex-col gap-4 w-full" {@rest}>
       <%= for {args, index} <- Enum.with_index(@trace.args) do %>
         <div :if={index > 0} class="border-t border-default-border w-full"></div>
         <div class="flex flex-col gap-4 w-full [&>div>div>button]:hidden hover:[&>div>div>button]:block">

--- a/lib/live_debugger/app/debugger/callback_tracing/web/global_traces_live.ex
+++ b/lib/live_debugger/app/debugger/callback_tracing/web/global_traces_live.ex
@@ -103,7 +103,7 @@ defmodule LiveDebugger.App.Debugger.CallbackTracing.Web.GlobalTracesLive do
             This view lists all callbacks inside debugged LiveView and its LiveComponents
           </span>
         </div>
-        <div class="w-full min-w-[20rem] flex flex-col pt-2 shadow-custom rounded-sm bg-surface-0-bg border border-default-border">
+        <div class="@container/traces w-full min-w-[20rem] flex flex-col pt-2 shadow-custom rounded-sm bg-surface-0-bg border border-default-border">
           <div class="w-full flex justify-between items-center border-b border-default-border pb-2">
             <div class="ml-2">
               <HookComponents.SearchInput.render

--- a/lib/live_debugger/app/debugger/callback_tracing/web/hook_components/filters_sidebar.ex
+++ b/lib/live_debugger/app/debugger/callback_tracing/web/hook_components/filters_sidebar.ex
@@ -32,16 +32,14 @@ defmodule LiveDebugger.App.Debugger.CallbackTracing.Web.HookComponents.FiltersSi
       <div class="flex flex-col justify-between h-full">
         <div>
           <div class="text-secondary-text font-semibold pt-6 pb-2 px-4">Filters</div>
-          <div class="px-3">
-            <.live_component
-              module={FiltersForm}
-              id="filters-sidebar-form"
-              node_id={nil}
-              filters={@current_filters}
-              disabled?={@tracing_started?}
-              revert_button_visible?={true}
-            />
-          </div>
+          <.live_component
+            module={FiltersForm}
+            id="filters-sidebar-form"
+            node_id={nil}
+            filters={@current_filters}
+            disabled?={@tracing_started?}
+            revert_button_visible?={true}
+          />
         </div>
         <.report_issue class="border-t border-default-border" />
       </div>

--- a/lib/live_debugger/app/debugger/callback_tracing/web/hook_components/filters_sidebar.ex
+++ b/lib/live_debugger/app/debugger/callback_tracing/web/hook_components/filters_sidebar.ex
@@ -29,18 +29,21 @@ defmodule LiveDebugger.App.Debugger.CallbackTracing.Web.HookComponents.FiltersSi
   def render(assigns) do
     ~H"""
     <.sidebar_slide_over id="filters-sidebar" sidebar_hidden?={@sidebar_hidden?}>
-      <div>
-        <div class="text-secondary-text font-semibold pt-6 pb-2 px-4">Filters</div>
-        <div class="px-3">
-          <.live_component
-            module={FiltersForm}
-            id="filters-sidebar-form"
-            node_id={nil}
-            filters={@current_filters}
-            disabled?={@tracing_started?}
-            revert_button_visible?={true}
-          />
+      <div class="flex flex-col justify-between h-full">
+        <div>
+          <div class="text-secondary-text font-semibold pt-6 pb-2 px-4">Filters</div>
+          <div class="px-3">
+            <.live_component
+              module={FiltersForm}
+              id="filters-sidebar-form"
+              node_id={nil}
+              filters={@current_filters}
+              disabled?={@tracing_started?}
+              revert_button_visible?={true}
+            />
+          </div>
         </div>
+        <.report_issue class="border-t border-default-border" />
       </div>
     </.sidebar_slide_over>
     """

--- a/lib/live_debugger/app/debugger/callback_tracing/web/live_components/filters_form.ex
+++ b/lib/live_debugger/app/debugger/callback_tracing/web/live_components/filters_form.ex
@@ -58,52 +58,58 @@ defmodule LiveDebugger.App.Debugger.CallbackTracing.Web.LiveComponents.FiltersFo
     ~H"""
     <div id={@id <> "-wrapper"} class={if @disabled?, do: "opacity-50 pointer-events-none"}>
       <.form for={@form} phx-submit="submit" phx-change="change" phx-target={@myself}>
-        <div class="w-full px-1">
-          <FiltersComponents.filters_group_header
-            title="Callbacks"
-            group_name={:functions}
-            target={@myself}
-            group_changed?={FiltersHelpers.group_changed?(@form.params, @default_filters, :functions)}
-          />
-          <div class="flex flex-col gap-3 pl-0.5 pb-4 border-b border-default-border">
-            <.checkbox
-              :for={callback <- FiltersHelpers.get_callbacks(@node_id)}
-              field={@form[callback]}
-              label={callback}
+        <div class="w-full py-2">
+          <div class="px-4 border-b border-default-border">
+            <FiltersComponents.filters_group_header
+              title="Callbacks"
+              group_name={:functions}
+              target={@myself}
+              group_changed?={
+                FiltersHelpers.group_changed?(@form.params, @default_filters, :functions)
+              }
             />
-          </div>
-          <FiltersComponents.filters_group_header
-            title="Execution Time"
-            class="pt-2"
-            group_name={:execution_time}
-            target={@myself}
-            group_changed?={
-              FiltersHelpers.group_changed?(@form.params, @default_filters, :execution_time)
-            }
-          />
-          <div class="pb-5">
-            <div class="flex gap-3 items-center">
-              <.input_with_units
-                value_field={@form[:exec_time_min]}
-                unit_field={@form[:min_unit]}
-                units={Parsers.time_units()}
-                min="0"
-                placeholder="min"
-              /> -
-              <.input_with_units
-                value_field={@form[:exec_time_max]}
-                unit_field={@form[:max_unit]}
-                min="0"
-                units={Parsers.time_units()}
-                placeholder="max"
+            <div class="flex flex-col gap-3 pb-4 ">
+              <.checkbox
+                :for={callback <- FiltersHelpers.get_callbacks(@node_id)}
+                field={@form[callback]}
+                label={callback}
               />
             </div>
-            <p :for={{_, msg} <- @errors} class="mt-2 block text-error-text">
-              <%= msg %>
-            </p>
+          </div>
+          <div class="px-4 border-b border-default-border">
+            <FiltersComponents.filters_group_header
+              title="Execution Time"
+              class="pt-2"
+              group_name={:execution_time}
+              target={@myself}
+              group_changed?={
+                FiltersHelpers.group_changed?(@form.params, @default_filters, :execution_time)
+              }
+            />
+            <div class="pb-5">
+              <div class="flex gap-3 items-center">
+                <.input_with_units
+                  value_field={@form[:exec_time_min]}
+                  unit_field={@form[:min_unit]}
+                  units={Parsers.time_units()}
+                  min="0"
+                  placeholder="min"
+                /> -
+                <.input_with_units
+                  value_field={@form[:exec_time_max]}
+                  unit_field={@form[:max_unit]}
+                  min="0"
+                  units={Parsers.time_units()}
+                  placeholder="max"
+                />
+              </div>
+              <p :for={{_, msg} <- @errors} class="mt-2 block text-error-text">
+                <%= msg %>
+              </p>
+            </div>
           </div>
 
-          <div class="flex pt-4 pb-2 border-t border-default-border items-center justify-between pr-3">
+          <div class="flex pt-4 pb-2 px-4 items-center justify-between pr-3">
             <div class="flex gap-2 items-center h-10">
               <%= if FiltersHelpers.filters_changed?(@form.params, @active_filters) do %>
                 <.button

--- a/lib/live_debugger/app/debugger/components_tree/utils.ex
+++ b/lib/live_debugger/app/debugger/components_tree/utils.ex
@@ -95,13 +95,17 @@ defmodule LiveDebugger.App.Debugger.ComponentsTree.Utils do
   defp add_children(parent_element, nil, _live_components), do: parent_element
 
   defp add_children(parent_element, children_cids_map, live_components) do
-    Enum.reduce(children_cids_map, parent_element, fn {cid, children_cids_map}, parent_element ->
-      child =
-        live_components
-        |> Enum.find(fn element -> element.id.cid == cid end)
-        |> add_children(children_cids_map, live_components)
+    tree_node =
+      Enum.reduce(children_cids_map, parent_element, fn {cid, children_cids_map},
+                                                        parent_element ->
+        child =
+          live_components
+          |> Enum.find(fn element -> element.id.cid == cid end)
+          |> add_children(children_cids_map, live_components)
 
-      TreeNode.add_child(parent_element, child)
-    end)
+        TreeNode.add_child(parent_element, child)
+      end)
+
+    %{tree_node | children: Enum.sort_by(tree_node.children, & &1.id.cid)}
   end
 end

--- a/lib/live_debugger/app/debugger/components_tree/web/components.ex
+++ b/lib/live_debugger/app/debugger/components_tree/web/components.ex
@@ -55,7 +55,10 @@ defmodule LiveDebugger.App.Debugger.ComponentsTree.Web.Components do
       id={"collapsible-#{@id}-#{@parsed_node_id}"}
       chevron_class="text-accent-icon h-5 w-5"
       open={@open}
-      label_class="rounded-md py-1 hover:bg-surface-1-bg-hover"
+      label_class={[
+        "rounded-md py-1 hover:bg-surface-1-bg-hover",
+        if(@selected?, do: "bg-surface-1-bg-hover")
+      ]}
       style={style_for_padding(@level, @collapsible?)}
     >
       <:label>
@@ -119,7 +122,8 @@ defmodule LiveDebugger.App.Debugger.ComponentsTree.Web.Components do
       phx-value-id={TreeNode.parse_id(@tree_node)}
       class={[
         "flex shrink grow items-center rounded-md hover:bg-surface-1-bg-hover",
-        if(!@collapsible?, do: "p-1")
+        if(!@collapsible?, do: "p-1"),
+        if(@selected?, do: "bg-surface-1-bg-hover font-semibold")
       ]}
       style={if(!@collapsible?, do: @padding_style)}
     >
@@ -136,7 +140,7 @@ defmodule LiveDebugger.App.Debugger.ComponentsTree.Web.Components do
       >
         <.icon name={@icon} class="text-accent-icon w-4 h-4 shrink-0" />
         <.tooltip id={@id <> "-tooltip"} content={@tooltip_content} class="truncate">
-          <span class={["hover:underline", if(@selected?, do: "font-semibold")]}>
+          <span class="hover:underline">
             <%= @label %>
           </span>
         </.tooltip>

--- a/lib/live_debugger/app/debugger/components_tree/web/components.ex
+++ b/lib/live_debugger/app/debugger/components_tree/web/components.ex
@@ -150,7 +150,7 @@ defmodule LiveDebugger.App.Debugger.ComponentsTree.Web.Components do
   end
 
   defp style_for_padding(level, collapsible?) do
-    padding = (level + 1) * 0.5 + if(collapsible?, do: 0, else: 1.5)
+    padding = (level + 1) * 0.5 + if(collapsible?, do: 0.25, else: 1.5)
 
     "padding-left: #{padding}rem;"
   end

--- a/lib/live_debugger/app/debugger/node_state/web/components.ex
+++ b/lib/live_debugger/app/debugger/node_state/web/components.ex
@@ -45,10 +45,12 @@ defmodule LiveDebugger.App.Debugger.NodeState.Web.Components do
       </div>
     </.section>
     <.fullscreen id={@fullscreen_id} title="Assigns">
-      <ElixirDisplay.term
-        id="assigns-display-fullscreen-term"
-        node={TermParser.term_to_display_tree(@assigns)}
-      />
+      <div class="p-4">
+        <ElixirDisplay.term
+          id="assigns-display-fullscreen-term"
+          node={TermParser.term_to_display_tree(@assigns)}
+        />
+      </div>
     </.fullscreen>
     """
   end

--- a/lib/live_debugger/app/debugger/web/components/navigation_menu.ex
+++ b/lib/live_debugger/app/debugger/web/components/navigation_menu.ex
@@ -84,11 +84,14 @@ defmodule LiveDebugger.App.Debugger.Web.Components.NavigationMenu do
   def dropdown_item(assigns) do
     ~H"""
     <div
-      class="flex gap-1.5 p-2 rounded items-center w-full hover:bg-surface-0-bg-hover cursor-pointer"
+      class={[
+        "flex gap-1.5 p-2 rounded items-center w-full hover:bg-surface-0-bg-hover cursor-pointer",
+        if(@selected?, do: "bg-surface-0-bg-hover font-semibold")
+      ]}
       {@rest}
     >
       <.icon name={@icon} class="h-4 w-4" />
-      <span class={if @selected?, do: "font-semibold"}>{@label}</span>
+      <span>{@label}</span>
     </div>
     """
   end

--- a/lib/live_debugger/app/web/components.ex
+++ b/lib/live_debugger/app/web/components.ex
@@ -457,7 +457,7 @@ defmodule LiveDebugger.App.Web.Components do
           variant="secondary"
         />
       </div>
-      <div class="overflow-auto flex flex-col gap-2 p-4 text-primary-text">
+      <div class="overflow-auto flex flex-col gap-2 text-primary-text">
         <%= render_slot(@inner_block) %>
       </div>
     </dialog>


### PR DESCRIPTION
Full list of changes:

- Add background highlight to current node in components tree
- Fix padding of collapsible and non-collapsible elements in components tree
- Add background highlight of current page in navigation menu in dropdown
- Fix padding of fullscreens (traces, assigns, filters):
- Fix: traces separators are too short when content is not filling the modal of fullscreen
- Fix buttons labels in global callbacks depending on screen width
- Add "report issue" in global callbacks sidebar

Additionally when there is more then 32 LiveComponents they are displayed in a random order inside Components Tree (due to how Maps with integer keys work). That's why I sort them by cid which corresponds to the order of their render in a LiveView.