### PR TITLE
Explicit formats in  SocketDiscoveryController

### DIFF
--- a/lib/live_debugger/app/controllers/socket_discovery_controller.ex
+++ b/lib/live_debugger/app/controllers/socket_discovery_controller.ex
@@ -1,5 +1,5 @@
 defmodule LiveDebugger.App.Controllers.SocketDiscoveryController do
-  use Phoenix.Controller
+  use Phoenix.Controller, formats: []
 
   alias LiveDebugger.API.LiveViewDiscovery
   alias LiveDebugger.App.Web.Helpers.Routes, as: RoutesHelper


### PR DESCRIPTION
Fixes compilation warning.

Before:

```
==> live_debugger
Compiling 127 files (.ex)
warning: use LiveDebugger.App.Controllers.SocketDiscoveryController must receive the :formats option with the formats you intend to render. To keep compatibility within your app, you can list it as:

    formats: [html: "View", json: "View", ...]

Listing all formats your application renders.
```

After: no warning.

---

The controller only does a redirect, it never renders any format, so the empty list should be suitable for now.