### PR TITLE
Feature: Better visual indication of assigns changes

### DIFF
--- a/assets/app/app.js
+++ b/assets/app/app.js
@@ -12,6 +12,7 @@ import TraceExecutionTime from './hooks/trace_execution_time';
 import CopyButton from './hooks/copy_button';
 import TraceBodySearchHighlight from './hooks/trace_body_search_highlight';
 import TraceLabelSearchHighlight from './hooks/trace_label_search_highlight';
+import DiffPulse from './hooks/diff_pulse';
 
 import topbar from './vendor/topbar';
 
@@ -36,6 +37,7 @@ function createHooks() {
     CopyButton,
     TraceBodySearchHighlight,
     TraceLabelSearchHighlight,
+    DiffPulse,
   };
 }
 

--- a/assets/app/hooks/diff_pulse.js
+++ b/assets/app/hooks/diff_pulse.js
@@ -1,9 +1,29 @@
 const DiffPulse = {
   mounted() {
-    this.el.classList.add('animate-diff-pulse');
-    this.timeout = setTimeout(() => {
+    if (this.el.hasAttribute('data-pulse')) {
+      this.el.removeAttribute('data-pulse');
+
+      this.el.classList.add('animate-diff-pulse');
+
+      this.timeout = setTimeout(() => {
+        this.el.classList.remove('animate-diff-pulse');
+      }, 500);
+    }
+  },
+  updated() {
+    if (this.el.hasAttribute('data-pulse')) {
+      clearTimeout(this.timeout);
+      this.el.removeAttribute('data-pulse');
       this.el.classList.remove('animate-diff-pulse');
-    }, 500);
+
+      setTimeout(() => {
+        this.el.classList.add('animate-diff-pulse');
+      });
+
+      this.timeout = setTimeout(() => {
+        this.el.classList.remove('animate-diff-pulse');
+      }, 500);
+    }
   },
   destroyed() {
     clearTimeout(this.timeout);

--- a/assets/app/hooks/diff_pulse.js
+++ b/assets/app/hooks/diff_pulse.js
@@ -1,0 +1,13 @@
+const DiffPulse = {
+  mounted() {
+    this.el.classList.add('animate-diff-pulse');
+    this.timeout = setTimeout(() => {
+      this.el.classList.remove('animate-diff-pulse');
+    }, 500);
+  },
+  destroyed() {
+    clearTimeout(this.timeout);
+  },
+};
+
+export default DiffPulse;

--- a/assets/app/hooks/diff_pulse.js
+++ b/assets/app/hooks/diff_pulse.js
@@ -16,9 +16,7 @@ const DiffPulse = {
       this.el.removeAttribute('data-pulse');
       this.el.classList.remove('animate-diff-pulse');
 
-      setTimeout(() => {
-        this.el.classList.add('animate-diff-pulse');
-      });
+      setTimeout(() => this.el.classList.add('animate-diff-pulse'));
 
       this.timeout = setTimeout(() => {
         this.el.classList.remove('animate-diff-pulse');

--- a/assets/app/styles/themes/dark.css
+++ b/assets/app/styles/themes/dark.css
@@ -66,16 +66,19 @@
     --error-icon: var(--swm-pink-80);
     --error-text: var(--swm-pink-80);
 
+    /* Info */
+    --info-bg: var(--surface-0-bg);
+    --info-border: var(--default-border);
+    --info-icon: var(--primary-text);
+    --info-text: var(--primary-text);
+
     /* Warning */
     --warning-text: var(--swm-yellow-40);
 
     --search-highlight-bg: var(--swm-yellow-100);
     --search-highlight-text: var(--gray-900);
 
-    /* Info */
-    --info-bg: var(--surface-0-bg);
-    --info-border: var(--default-border);
-    --info-icon: var(--primary-text);
-    --info-text: var(--primary-text);
+    --diff-pulse-bg: var(--swm-sea-blue-60);
+    --diff-pulse-text: var(--gray-900);
   }
 }

--- a/assets/app/styles/themes/light.css
+++ b/assets/app/styles/themes/light.css
@@ -76,4 +76,7 @@
 
   --search-highlight-bg: var(--swm-yellow-80);
   --search-highlight-text: var(--slate-900);
+
+  --diff-pulse-bg: var(--swm-sea-blue-60);
+  --diff-pulse-text: var(--slate-900);
 }

--- a/assets/app/tailwind.config.js
+++ b/assets/app/tailwind.config.js
@@ -86,10 +86,16 @@ module.exports = {
           '0%': { opacity: '1', transform: 'translateY(0)' },
           '100%': { opacity: '0', transform: 'translateY(1rem)' },
         },
+        diffPulse: {
+          '0%': { backgroundColor: 'inherit' },
+          '50%': { backgroundColor: 'yellow' },
+          '100%': { backgroundColor: 'inherit' },
+        },
       },
       animation: {
         'fade-out': 'fadeOut 200ms ease-out forwards',
         'fade-out-mobile': 'fadeOutMobile 200ms ease-out forwards',
+        'diff-pulse': 'diffPulse 500ms ease-in-out',
       },
     },
   },

--- a/assets/app/tailwind.config.js
+++ b/assets/app/tailwind.config.js
@@ -87,15 +87,17 @@ module.exports = {
           '100%': { opacity: '0', transform: 'translateY(1rem)' },
         },
         diffPulse: {
-          '0%': { backgroundColor: 'inherit' },
-          '50%': { backgroundColor: 'yellow' },
-          '100%': { backgroundColor: 'inherit' },
+          '0%': {
+            backgroundColor: 'var(--diff-pulse-bg)',
+            color: 'var(--diff-pulse-text)',
+          },
+          '100%': { backgroundColor: '', color: '' },
         },
       },
       animation: {
         'fade-out': 'fadeOut 200ms ease-out forwards',
         'fade-out-mobile': 'fadeOutMobile 200ms ease-out forwards',
-        'diff-pulse': 'diffPulse 500ms ease-in-out',
+        'diff-pulse': 'diffPulse 600ms ease-out',
       },
     },
   },

--- a/dev/live_views/side.ex
+++ b/dev/live_views/side.ex
@@ -5,13 +5,17 @@ defmodule LiveDebuggerDev.LiveViews.Side do
     current_pid = self()
 
     Task.start(fn ->
-      for _ <- 1..100_000 do
+      for i <- 1..100_000 do
         Process.sleep(8)
         send(current_pid, :hello)
+
+        if rem(i, 100) == 0 do
+          send(current_pid, :increment)
+        end
       end
     end)
 
-    {:ok, socket}
+    {:ok, assign(socket, counter: 0)}
   end
 
   def render(assigns) do
@@ -24,5 +28,9 @@ defmodule LiveDebuggerDev.LiveViews.Side do
 
   def handle_info(:hello, socket) do
     {:noreply, socket}
+  end
+
+  def handle_info(:increment, socket) do
+    {:noreply, update(socket, :counter, &(&1 + 1))}
   end
 end

--- a/lib/live_debugger/app/debugger/node_state/queries.ex
+++ b/lib/live_debugger/app/debugger/node_state/queries.ex
@@ -9,7 +9,7 @@ defmodule LiveDebugger.App.Debugger.NodeState.Queries do
   alias LiveDebugger.App.Debugger.Structs.TreeNode
 
   @spec fetch_node_assigns(pid :: pid(), node_id :: TreeNode.id()) ::
-          {:ok, %{node_assigns: map()}} | {:error, term()}
+          {:ok, map()} | {:error, term()}
   def fetch_node_assigns(pid, node_id) when is_pid(node_id) do
     case fetch_node_state(pid) do
       {:ok, %LvState{socket: %{assigns: assigns}}} ->

--- a/lib/live_debugger/app/debugger/node_state/queries.ex
+++ b/lib/live_debugger/app/debugger/node_state/queries.ex
@@ -13,7 +13,7 @@ defmodule LiveDebugger.App.Debugger.NodeState.Queries do
   def fetch_node_assigns(pid, node_id) when is_pid(node_id) do
     case fetch_node_state(pid) do
       {:ok, %LvState{socket: %{assigns: assigns}}} ->
-        {:ok, %{node_assigns: assigns}}
+        {:ok, assigns}
 
       {:error, reason} ->
         {:error, reason}
@@ -49,7 +49,7 @@ defmodule LiveDebugger.App.Debugger.NodeState.Queries do
         {:error, "Component with CID #{cid} not found"}
 
       component ->
-        {:ok, %{node_assigns: component.assigns}}
+        {:ok, component.assigns}
     end
   end
 end

--- a/lib/live_debugger/app/debugger/node_state/utils.ex
+++ b/lib/live_debugger/app/debugger/node_state/utils.ex
@@ -1,0 +1,42 @@
+defmodule LiveDebugger.App.Debugger.NodeState.Utils do
+  @moduledoc """
+  Utility functions for the Node State.
+  """
+
+  @doc """
+  Computes a recursive diff between two maps.
+  Returns a map of keys that changed, where
+  leaf values are `true`.
+  """
+  @spec diff(map(), map()) :: map()
+  def diff(map1, map2) when is_map(map1) and is_map(map2) do
+    all_keys = (Map.keys(map1) ++ Map.keys(map2)) |> Enum.uniq()
+
+    all_keys
+    |> Enum.reduce(%{}, fn key, acc ->
+      v1 = Map.get(map1, key, :__missing__)
+      v2 = Map.get(map2, key, :__missing__)
+
+      cond do
+        v1 == v2 ->
+          acc
+
+        is_map(v1) and is_map(v2) ->
+          nested_diff = diff(v1, v2)
+
+          if nested_diff == %{} do
+            acc
+          else
+            Map.put(acc, key, nested_diff)
+          end
+
+        true ->
+          Map.put(acc, key, true)
+      end
+    end)
+  end
+
+  def diff(_, _) do
+    %{}
+  end
+end

--- a/lib/live_debugger/app/debugger/node_state/utils.ex
+++ b/lib/live_debugger/app/debugger/node_state/utils.ex
@@ -17,26 +17,18 @@ defmodule LiveDebugger.App.Debugger.NodeState.Utils do
       v1 = Map.get(map1, key, :__missing__)
       v2 = Map.get(map2, key, :__missing__)
 
-      cond do
-        v1 == v2 ->
-          acc
-
-        is_map(v1) and is_map(v2) ->
-          nested_diff = diff(v1, v2)
-
-          if nested_diff == %{} do
-            acc
-          else
-            Map.put(acc, key, nested_diff)
-          end
-
-        true ->
-          Map.put(acc, key, true)
+      case compare_values(v1, v2) do
+        res when res in [nil, %{}] -> acc
+        res -> Map.put(acc, key, res)
       end
     end)
   end
 
-  def diff(_, _) do
-    %{}
+  defp compare_values(v1, v2) do
+    cond do
+      v1 == v2 -> nil
+      is_map(v1) and is_map(v2) -> diff(v1, v2)
+      true -> true
+    end
   end
 end

--- a/lib/live_debugger/app/debugger/node_state/web/components.ex
+++ b/lib/live_debugger/app/debugger/node_state/web/components.ex
@@ -25,6 +25,7 @@ defmodule LiveDebugger.App.Debugger.NodeState.Web.Components do
   end
 
   attr(:assigns, :list, required: true)
+  attr(:diff, :map, default: %{})
   attr(:fullscreen_id, :string, required: true)
 
   def assigns_section(assigns) do
@@ -41,14 +42,17 @@ defmodule LiveDebugger.App.Debugger.NodeState.Web.Components do
         </div>
       </:right_panel>
       <div class="relative w-full h-max max-h-full p-4 overflow-y-auto">
-        <ElixirDisplay.term id="assigns-display" node={TermParser.term_to_display_tree(@assigns)} />
+        <ElixirDisplay.term
+          id="assigns-display"
+          node={TermParser.term_to_display_tree(@assigns, @diff)}
+        />
       </div>
     </.section>
     <.fullscreen id={@fullscreen_id} title="Assigns">
       <div class="p-4">
         <ElixirDisplay.term
           id="assigns-display-fullscreen-term"
-          node={TermParser.term_to_display_tree(@assigns)}
+          node={TermParser.term_to_display_tree(@assigns, @diff)}
         />
       </div>
     </.fullscreen>

--- a/lib/live_debugger/app/debugger/node_state/web/hooks/node_assigns.ex
+++ b/lib/live_debugger/app/debugger/node_state/web/hooks/node_assigns.ex
@@ -1,0 +1,76 @@
+defmodule LiveDebugger.App.Debugger.NodeState.Web.Hooks.NodeAssigns do
+  @moduledoc """
+  This hook is responsible for fetching assigns of specific node.
+  """
+
+  use LiveDebugger.App.Web, :hook
+
+  alias Phoenix.LiveView.AsyncResult
+  alias LiveDebugger.App.Debugger.NodeState.Utils, as: NodeStateUtils
+  alias LiveDebugger.App.Debugger.NodeState.Queries, as: NodeStateQueries
+
+  @required_assigns [
+    :node_id,
+    :lv_process
+  ]
+
+  @doc """
+  Initializes the hook by attaching the hook to the socket and checking the required assigns.
+  """
+  @spec init(Phoenix.LiveView.Socket.t()) :: Phoenix.LiveView.Socket.t()
+  def init(socket) do
+    socket
+    |> check_assigns!(@required_assigns)
+    |> attach_hook(:node_assigns, :handle_async, &handle_async/3)
+    |> register_hook(:node_assigns)
+    |> assign(:node_assigns, AsyncResult.loading())
+    |> assign(:node_assigns_diff, AsyncResult.loading())
+    |> assign_async_node_assigns()
+  end
+
+  defp handle_async(:fetch_node_assigns, {:ok, {:ok, node_assigns}}, socket) do
+    diff =
+      case socket.assigns.node_assigns.result do
+        nil -> %{}
+        old_node_assigns -> NodeStateUtils.diff(old_node_assigns, node_assigns)
+      end
+
+    socket
+    |> assign(:node_assigns, AsyncResult.ok(node_assigns))
+    |> assign(:node_assigns_diff, AsyncResult.ok(diff))
+    |> halt()
+  end
+
+  defp handle_async(:fetch_node_assigns, {:ok, {:error, reason}}, socket) do
+    socket
+    |> assign(:node_assigns, AsyncResult.failed(socket.node_assigns, reason))
+    |> assign(:node_assigns_diff, AsyncResult.failed(socket.node_assigns_diff, reason))
+    |> halt()
+  end
+
+  defp handle_async(:fetch_node_assigns, {:exit, reason}, socket) do
+    socket
+    |> assign(:node_assigns, AsyncResult.failed(socket.node_assigns, reason))
+    |> assign(:node_assigns_diff, AsyncResult.failed(socket.node_assigns_diff, reason))
+    |> halt()
+  end
+
+  defp handle_async(_, _, socket), do: {:cont, socket}
+
+  def assign_async_node_assigns(socket)
+
+  def assign_async_node_assigns(%{assigns: %{node_id: node_id, lv_process: %{pid: pid}}} = socket)
+      when not is_nil(node_id) do
+    socket
+    |> start_async(:fetch_node_assigns, fn ->
+      # Small sleep serves here as a debounce mechanism
+      Process.sleep(100)
+      NodeStateQueries.fetch_node_assigns(pid, node_id)
+    end)
+  end
+
+  def assign_async_node_assigns(socket) do
+    assign(socket, :node_assigns, AsyncResult.failed(%AsyncResult{}, :no_node_id))
+    assign(socket, :node_assigns_diff, AsyncResult.failed(%AsyncResult{}, :no_node_id))
+  end
+end

--- a/lib/live_debugger/app/debugger/node_state/web/node_state_live.ex
+++ b/lib/live_debugger/app/debugger/node_state/web/node_state_live.ex
@@ -10,6 +10,7 @@ defmodule LiveDebugger.App.Debugger.NodeState.Web.NodeStateLive do
   alias LiveDebugger.Structs.LvProcess
   alias LiveDebugger.App.Debugger.NodeState.Web.Components, as: NodeStateComponents
   alias LiveDebugger.App.Debugger.NodeState.Queries, as: NodeStateQueries
+  alias LiveDebugger.App.Debugger.NodeState.Utils, as: NodeStateUtils
 
   alias LiveDebugger.Bus
   alias LiveDebugger.App.Debugger.Events.NodeIdParamChanged
@@ -126,7 +127,7 @@ defmodule LiveDebugger.App.Debugger.NodeState.Web.NodeStateLive do
         {:ok, node_assigns} ->
           diff =
             if calculate_diff? do
-              MapDiff.diff(old_node_assigns, node_assigns)
+              NodeStateUtils.diff(old_node_assigns, node_assigns)
             else
               %{}
             end
@@ -143,43 +144,5 @@ defmodule LiveDebugger.App.Debugger.NodeState.Web.NodeStateLive do
 
   defp assign_async_node_assigns(socket, _opts) do
     assign(socket, :node, AsyncResult.failed(%AsyncResult{}, :no_node_id))
-  end
-end
-
-defmodule MapDiff do
-  @doc """
-  Computes a recursive diff between two maps.
-  Returns a map of keys that changed, where
-  leaf values are tuples {old, new}.
-  """
-  def diff(map1, map2) when is_map(map1) and is_map(map2) do
-    all_keys = (Map.keys(map1) ++ Map.keys(map2)) |> Enum.uniq()
-
-    all_keys
-    |> Enum.reduce(%{}, fn key, acc ->
-      v1 = Map.get(map1, key, :__missing__)
-      v2 = Map.get(map2, key, :__missing__)
-
-      cond do
-        v1 == v2 ->
-          acc
-
-        is_map(v1) and is_map(v2) ->
-          nested_diff = diff(v1, v2)
-
-          if nested_diff == %{} do
-            acc
-          else
-            Map.put(acc, key, nested_diff)
-          end
-
-        true ->
-          Map.put(acc, key, true)
-      end
-    end)
-  end
-
-  def diff(_, _) do
-    %{}
   end
 end

--- a/lib/live_debugger/app/debugger/node_state/web/node_state_live.ex
+++ b/lib/live_debugger/app/debugger/node_state/web/node_state_live.ex
@@ -106,7 +106,7 @@ defmodule LiveDebugger.App.Debugger.NodeState.Web.NodeStateLive do
 
   def handle_info(%StateChanged{}, socket) do
     socket
-    |> Hooks.NodeAssigns.assign_async_node_assigns()
+    |> Hooks.NodeAssigns.assign_async_node_assigns(with_diff?: true)
     |> noreply()
   end
 

--- a/lib/live_debugger/app/debugger/web/components/elixir_display.ex
+++ b/lib/live_debugger/app/debugger/web/components/elixir_display.ex
@@ -20,6 +20,10 @@ defmodule LiveDebugger.App.Debugger.Web.Components.ElixirDisplay do
   attr(:level, :integer, default: 1)
 
   def term(assigns) do
+    if assigns.node.diffed do
+      dbg(assigns.node)
+    end
+
     assigns =
       assigns
       |> assign(:expanded?, auto_expand?(assigns.node, assigns.level))

--- a/lib/live_debugger/app/debugger/web/components/elixir_display.ex
+++ b/lib/live_debugger/app/debugger/web/components/elixir_display.ex
@@ -28,7 +28,7 @@ defmodule LiveDebugger.App.Debugger.Web.Components.ElixirDisplay do
     ~H"""
     <div class="font-code">
       <div class="ml-[2ch]">
-        <.text_items :if={!@has_children?} items={@node.content} />
+        <.text_items :if={!@has_children?} id={@id} items={@node.content} />
       </div>
       <.collapsible
         :if={@has_children?}
@@ -41,10 +41,10 @@ defmodule LiveDebugger.App.Debugger.Web.Components.ElixirDisplay do
         <:label>
           <div class="flex items-center">
             <div class="show-on-open">
-              <.text_items items={@node.expanded_before} />
+              <.text_items id={@id <> "expanded_before"} items={@node.expanded_before} />
             </div>
             <div class="hide-on-open">
-              <.text_items items={@node.content} />
+              <.text_items id={@id <> "content"} items={@node.content} />
             </div>
           </div>
         </:label>
@@ -57,22 +57,24 @@ defmodule LiveDebugger.App.Debugger.Web.Components.ElixirDisplay do
           <% end %>
         </ol>
         <div class="ml-[2ch]">
-          <.text_items items={@node.expanded_after} />
+          <.text_items id={@id <> "expanded_after"} items={@node.expanded_after} />
         </div>
       </.collapsible>
     </div>
     """
   end
 
+  attr(:id, :string, required: true)
   attr(:items, :list, required: true)
 
   defp text_items(assigns) do
     ~H"""
     <div class="flex">
-      <%= for item <- @items do %>
+      <%= for {item, index} <- Enum.with_index(@items) do %>
         <span
-          id={:rand.uniform() |> to_string}
-          phx-hook={if(item.pulse?, do: "DiffPulse")}
+          id={@id <> "-#{index}"}
+          phx-hook="DiffPulse"
+          data-pulse={item.pulse?}
           class={"#{text_item_color_class(item)}"}
         >
           <pre data-text_item="true"><%= item.text %></pre>

--- a/lib/live_debugger/app/debugger/web/components/elixir_display.ex
+++ b/lib/live_debugger/app/debugger/web/components/elixir_display.ex
@@ -20,10 +20,6 @@ defmodule LiveDebugger.App.Debugger.Web.Components.ElixirDisplay do
   attr(:level, :integer, default: 1)
 
   def term(assigns) do
-    if assigns.node.diffed do
-      dbg(assigns.node)
-    end
-
     assigns =
       assigns
       |> assign(:expanded?, auto_expand?(assigns.node, assigns.level))
@@ -74,7 +70,11 @@ defmodule LiveDebugger.App.Debugger.Web.Components.ElixirDisplay do
     ~H"""
     <div class="flex">
       <%= for item <- @items do %>
-        <span class={"#{text_item_color_class(item)}"}>
+        <span
+          id={:rand.uniform() |> to_string}
+          phx-hook={if(item.pulse?, do: "DiffPulse")}
+          class={"#{text_item_color_class(item)}"}
+        >
           <pre data-text_item="true"><%= item.text %></pre>
         </span>
       <% end %>

--- a/lib/live_debugger/app/utils/term_parser.ex
+++ b/lib/live_debugger/app/utils/term_parser.ex
@@ -60,11 +60,13 @@ defmodule LiveDebugger.App.Utils.TermParser do
   end
 
   defp to_node(atom, suffix, diff) when is_atom(atom) do
+    diffed = diff != %{}
+
     span =
       if atom in [nil, true, false] do
-        magenta(inspect(atom), diff != %{})
+        magenta(inspect(atom), diffed)
       else
-        blue(inspect(atom), diff != %{})
+        blue(inspect(atom), diffed)
       end
 
     leaf_node("atom", [span | suffix])
@@ -123,15 +125,17 @@ defmodule LiveDebugger.App.Utils.TermParser do
   end
 
   defp to_node(%module{} = struct, suffix, diff) when is_struct(struct) do
+    diffed = diff != %{}
+
     content =
       if Inspect.impl_for(struct) in [Inspect.Any, Inspect.Phoenix.LiveView.Socket] do
         [
-          black("%", diff != %{}),
-          blue(inspect(module), diff != %{}),
-          black("{...}", diff != %{}) | suffix
+          black("%", diffed),
+          blue(inspect(module), diffed),
+          black("{...}", diffed) | suffix
         ]
       else
-        [black(inspect(struct), diff != %{}) | suffix]
+        [black(inspect(struct), diffed) | suffix]
       end
 
     map = Map.from_struct(struct)
@@ -142,7 +146,7 @@ defmodule LiveDebugger.App.Utils.TermParser do
       "struct",
       content,
       children,
-      [black("%"), blue(inspect(module), diff != %{}), black("{")],
+      [black("%"), blue(inspect(module), diffed), black("{")],
       [black("}") | suffix]
     )
   end
@@ -169,17 +173,19 @@ defmodule LiveDebugger.App.Utils.TermParser do
   end
 
   defp to_key_value_node({key, value}, suffix, diff) do
+    diffed = diff != %{}
+
     {key_span, sep_span} =
       case to_node(key, [], diff) do
         %TermNode{content: [%DisplayElement{text: ":" <> name} = span]} when is_atom(key) ->
-          {%{span | text: name <> ":"}, black(" ", diff != %{})}
+          {%{span | text: name <> ":"}, black(" ", diffed)}
 
         %TermNode{content: [span]} ->
-          {%{span | text: inspect(key, width: :infinity)}, black(" => ", diff != %{})}
+          {%{span | text: inspect(key, width: :infinity)}, black(" => ", diffed)}
 
         %TermNode{content: _content} ->
           {%DisplayElement{text: inspect(key, width: :infinity), color: "text-code-1"},
-           black(" => ", diff != %{})}
+           black(" => ", diffed)}
       end
 
     case to_node(value, suffix, diff) do

--- a/test/app/debugger/node_state/queries_test.exs
+++ b/test/app/debugger/node_state/queries_test.exs
@@ -18,7 +18,7 @@ defmodule LiveDebugger.App.Debugger.NodeState.QueriesTest do
       MockAPIStatesStorage
       |> expect(:get!, fn ^pid -> %LvState{socket: %{assigns: assigns}} end)
 
-      assert {:ok, %{node_assigns: ^assigns}} = NodeStateQueries.fetch_node_assigns(pid, pid)
+      assert {:ok, ^assigns} = NodeStateQueries.fetch_node_assigns(pid, pid)
     end
 
     test "returns assigns for a valid LiveView node when not saved in storage" do
@@ -32,7 +32,7 @@ defmodule LiveDebugger.App.Debugger.NodeState.QueriesTest do
       |> expect(:socket, fn ^pid -> {:ok, %{assigns: assigns}} end)
       |> expect(:live_components, fn ^pid -> {:ok, []} end)
 
-      assert {:ok, %{node_assigns: ^assigns}} = NodeStateQueries.fetch_node_assigns(pid, pid)
+      assert {:ok, ^assigns} = NodeStateQueries.fetch_node_assigns(pid, pid)
     end
 
     test "returns assigns for a valid component CID when saved in storage" do
@@ -43,7 +43,7 @@ defmodule LiveDebugger.App.Debugger.NodeState.QueriesTest do
       MockAPIStatesStorage
       |> expect(:get!, fn ^pid -> %LvState{components: [%{cid: cid.cid, assigns: assigns}]} end)
 
-      assert {:ok, %{node_assigns: ^assigns}} = NodeStateQueries.fetch_node_assigns(pid, cid)
+      assert {:ok, ^assigns} = NodeStateQueries.fetch_node_assigns(pid, cid)
     end
 
     test "returns assigns for a valid component CID when not saved in storage" do
@@ -58,7 +58,7 @@ defmodule LiveDebugger.App.Debugger.NodeState.QueriesTest do
       |> expect(:socket, fn ^pid -> {:ok, %{}} end)
       |> expect(:live_components, fn ^pid -> {:ok, [%{cid: cid.cid, assigns: assigns}]} end)
 
-      assert {:ok, %{node_assigns: ^assigns}} = NodeStateQueries.fetch_node_assigns(pid, cid)
+      assert {:ok, ^assigns} = NodeStateQueries.fetch_node_assigns(pid, cid)
     end
   end
 end

--- a/test/app/debugger/node_state/utils_test.exs
+++ b/test/app/debugger/node_state/utils_test.exs
@@ -1,0 +1,73 @@
+defmodule App.Debugger.NodeState.UtilsTest do
+  use ExUnit.Case, async: true
+
+  alias LiveDebugger.App.Debugger.NodeState.Utils, as: NodeStateUtils
+
+  defmodule SampleStruct do
+    defstruct [:field1, :field2]
+  end
+
+  test "diff_assigns/2 returns the correct diff between two maps" do
+    old_assigns = %{
+      a: 1,
+      b: 2,
+      c: %{
+        :d => [1, 2, 3],
+        32 => {:ok, %{result: "test"}}
+      },
+      e: %SampleStruct{field1: "value1", field2: "value2"},
+      f: %{
+        nested: %{
+          key1: "val1"
+        }
+      },
+      struct_as_key: %{
+        %SampleStruct{} => nil,
+        %SampleStruct{field1: 23} => nil
+      }
+    }
+
+    new_assigns = %{
+      a: 2,
+      b: 2,
+      c: %{
+        :d => [1, 2, 3, 4],
+        32 => {:ok, %{result: "test changed"}}
+      },
+      e: %SampleStruct{field1: "value1", field2: "other"},
+      f: %{
+        nested: %{
+          key2: "val1"
+        }
+      },
+      struct_as_key: %{
+        %SampleStruct{} => "some value",
+        %SampleStruct{field1: 1000} => nil
+      }
+    }
+
+    expected_diff = %{
+      a: true,
+      c: %{
+        :d => true,
+        32 => true
+      },
+      e: %{
+        field2: true
+      },
+      f: %{
+        nested: %{
+          key1: true,
+          key2: true
+        }
+      },
+      struct_as_key: %{
+        %SampleStruct{} => true,
+        %SampleStruct{field1: 23} => true,
+        %SampleStruct{field1: 1000} => true
+      }
+    }
+
+    assert NodeStateUtils.diff(old_assigns, new_assigns) == expected_diff
+  end
+end

--- a/test/e2e/dead_view_mode_test.exs
+++ b/test/e2e/dead_view_mode_test.exs
@@ -4,6 +4,7 @@ defmodule LiveDebugger.E2E.DeadViewModeTest do
   setup_all do
     LiveDebugger.Services.CallbackTracer.GenServers.TracingManager.ping!()
     LiveDebugger.API.SettingsStorage.save(:dead_view_mode, true)
+    LiveDebugger.API.SettingsStorage.save(:tracing_enabled_on_start, false)
 
     :ok
   end


### PR DESCRIPTION
To keep things simple and don't interfere with other features (like searching in assigns) I think that visually indicating where particular value changed in assigns shouldn't open any collapsibles and it should be always turned on.
I tried to implement this approach here.

cc @GuzekAlan @srzeszut 