### PR TITLE
Bug: Settings switch wrong state when clicking fast

### DIFF
--- a/assets/app/tailwind.config.js
+++ b/assets/app/tailwind.config.js
@@ -86,10 +86,20 @@ module.exports = {
           '0%': { opacity: '1', transform: 'translateY(0)' },
           '100%': { opacity: '0', transform: 'translateY(1rem)' },
         },
+        fadeIn: {
+          '0%': { opacity: '0', transform: 'scale(0.95)' },
+          '100%': { opacity: '1', transform: 'scale(1)' },
+        },
+        fadeInMobile: {
+          '0%': { opacity: '0', transform: 'translateY(1rem)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
       },
       animation: {
         'fade-out': 'fadeOut 200ms ease-out forwards',
         'fade-out-mobile': 'fadeOutMobile 200ms ease-out forwards',
+        'fade-in': 'fadeIn 100ms ease-in forwards',
+        'fade-in-mobile': 'fadeInMobile 100ms ease-in forwards',
       },
     },
   },

--- a/lib/live_debugger/app/settings/web/components.ex
+++ b/lib/live_debugger/app/settings/web/components.ex
@@ -92,7 +92,7 @@ defmodule LiveDebugger.App.Settings.Web.Components do
     |> JS.push(value: %{key: key})
     |> JS.hide(
       to: "#{to}",
-      time: 200,
+      time: 100,
       transition: "max-sm:animate-fade-out-mobile sm:animate-fade-out"
     )
   end

--- a/lib/live_debugger/app/web/components.ex
+++ b/lib/live_debugger/app/web/components.ex
@@ -193,7 +193,7 @@ defmodule LiveDebugger.App.Web.Components do
       phx-hook="AutoClearFlash"
       role="alert"
       class={[
-        "fixed left-2 bottom-2 w-80 sm:w-96 z-50 rounded-sm p-4 flex justify-between items-center gap-3",
+        "max-sm:animate-fade-in-mobile sm:animate-fade-in fixed left-2 bottom-2 w-80 sm:w-96 z-50 rounded-sm p-4 flex justify-between items-center gap-3",
         @kind == :error && "bg-error-bg text-error-text border-error-text border",
         @kind == :info &&
           "bg-info-bg text-info-text border-info-border border"


### PR DESCRIPTION
Root problem of this is clearing the flash on checkbox value change. Seems like decreasing the time from `200` to `100` fixes the issue.