### PR TITLE
Bug: flaky e2e test fix

### DIFF
--- a/test/e2e/dead_live_views_test.exs
+++ b/test/e2e/dead_live_views_test.exs
@@ -22,8 +22,11 @@ defmodule LiveDebugger.E2E.DeadLiveViewsTest do
     |> assert_has(enable_dead_liveviews_checkbox(selected: false))
     |> refute_has(css("#dead-sessions"))
     |> click(enable_dead_liveviews_toggle())
+
+    Process.sleep(200)
+
+    debugger
     |> assert_text(css("#dead-sessions"), "No dead LiveViews")
-    |> take_screenshot()
 
     dev_app
     |> visit(@dev_app_url <> "/side")


### PR DESCRIPTION
Since this test was merged e2e tests are failing more frequently because of it - added smal process sleep to get rid of potential race conditon

Not sure if this fixes this issue since I couldn't since it's not deterministic, we'll see how often tests are failing