### PR TITLE
Bug: fix error alert in traces

### DIFF
--- a/lib/live_debugger/app/debugger/callback_tracing/web/hook_components/stream.ex
+++ b/lib/live_debugger/app/debugger/callback_tracing/web/hook_components/stream.ex
@@ -26,8 +26,8 @@ defmodule LiveDebugger.App.Debugger.CallbackTracing.Web.HookComponents.Stream do
   def render(assigns) do
     ~H"""
     <div id={"#{@id}-stream"} phx-update="stream" class="flex flex-col gap-2">
-      <div id={"#{@id}-stream-empty"} class="only:block hidden text-secondary-text text-center">
-        <div :if={@existing_traces_status == :ok}>
+      <div id={"#{@id}-stream-empty"} class="only:block hidden">
+        <div :if={@existing_traces_status == :ok} class="text-secondary-text text-center">
           No traces have been recorded yet.
         </div>
         <div :if={@existing_traces_status == :loading} class="w-full flex items-center justify-center">


### PR DESCRIPTION
Before
<img width="792" height="224" alt="Screenshot 2025-11-18 at 15 13 18" src="https://github.com/user-attachments/assets/b7a28871-344f-476f-bd02-ff3e73b500b1" />


After
<img width="617" height="187" alt="Screenshot 2025-11-18 at 15 11 39" src="https://github.com/user-attachments/assets/10703361-c2ec-43d0-a2a9-9ed91a995f4d" />
