### PR TITLE
Bug: assigns minor UI fixes

### DIFF
--- a/lib/live_debugger/app/debugger/node_state/web/components.ex
+++ b/lib/live_debugger/app/debugger/node_state/web/components.ex
@@ -42,7 +42,7 @@ defmodule LiveDebugger.App.Debugger.NodeState.Web.Components do
 
     ~H"""
     <div id="assigns-section-container" phx-hook="AssignsBodySearchHighlight">
-      <.section id="assigns" class="h-max overflow-y-hidden" title="Assigns">
+      <.section id="assigns" class="h-max overflow-y-hidden" title="Assigns" title_class="!min-w-14">
         <:right_panel>
           <div class="flex gap-2">
             <AssignsSearch.render

--- a/lib/live_debugger/app/web/components.ex
+++ b/lib/live_debugger/app/web/components.ex
@@ -288,6 +288,7 @@ defmodule LiveDebugger.App.Web.Components do
   attr(:id, :string, required: true)
   attr(:title, :string, required: true)
   attr(:class, :any, default: nil)
+  attr(:title_class, :any, default: nil)
   attr(:inner_class, :any, default: nil)
 
   slot(:right_panel)
@@ -304,7 +305,7 @@ defmodule LiveDebugger.App.Web.Components do
     >
       <div class="pl-4 flex items-center h-12 p-2 border-b border-default-border">
         <div class="flex justify-between items-center w-full gap-2">
-          <div class="font-medium text-sm min-w-26"><%= @title %></div>
+          <div class={["font-medium text-sm min-w-26" | List.wrap(@title_class)]}><%= @title %></div>
           <div class="w-max">
             <%= render_slot(@right_panel) %>
           </div>


### PR DESCRIPTION
Before
<img width="604" height="610" alt="Screenshot 2025-11-25 at 12 48 27" src="https://github.com/user-attachments/assets/02ff11c9-9115-4a5f-a584-62570cb8727a" />

After:
<img width="594" height="601" alt="Screenshot 2025-11-25 at 12 47 17" src="https://github.com/user-attachments/assets/0e8d9d6e-d836-4757-ab8f-7d26a254c60f" />

Before:
<img width="596" height="136" alt="Screenshot 2025-11-25 at 12 48 16" src="https://github.com/user-attachments/assets/cf279c42-586f-487d-815e-177d49afa55c" />

After: 
<img width="687" height="142" alt="Screenshot 2025-11-25 at 12 51 31" src="https://github.com/user-attachments/assets/b7490e70-a54c-43f1-ab79-7dd0c9e9f8ac" />
