### PR TITLE
Bug: Fix LiveView first render issue

### DIFF
--- a/lib/live_debugger/services/callback_tracer/gen_servers/tracing_manager.ex
+++ b/lib/live_debugger/services/callback_tracer/gen_servers/tracing_manager.ex
@@ -11,7 +11,7 @@ defmodule LiveDebugger.Services.CallbackTracer.GenServers.TracingManager do
 
   alias LiveDebugger.Services.CallbackTracer.Actions.Tracing, as: TracingActions
 
-  @telemetry_event_name [:phoenix, :live_view, :mount, :start]
+  @telemetry_event_name [:phoenix, :live_view, :render, :stop]
 
   @type state() :: %{dbg_pid: pid() | nil}
 


### PR DESCRIPTION
For some reason due to early call to `dbg.stop` (after `[:phoenix, :live_view, :mount, :start]` telemetry event is registered) first LiveView lifecycle fails with `(RuntimeError) render/1 was not implemented for LiveDebuggerDev.LiveViews.Main`. Changing event to `:render, :stop` seems to fix it.