### PR TITLE
Set endpoint url config for correct Phoenix startup log

### DIFF
--- a/lib/live_debugger.ex
+++ b/lib/live_debugger.ex
@@ -56,12 +56,19 @@ defmodule LiveDebugger do
   end
 
   defp put_endpoint_config(config) do
+    ip = Keyword.get(config, :ip, @default_ip)
+    port = Keyword.get(config, :port, @default_port)
+
+    host =
+      case Keyword.get(config, :external_url) do
+        nil -> ip |> :inet.ntoa() |> List.to_string()
+        url -> URI.parse(url).host
+      end
+
     endpoint_config =
       [
-        http: [
-          ip: Keyword.get(config, :ip, @default_ip),
-          port: Keyword.get(config, :port, @default_port)
-        ],
+        http: [ip: ip, port: port],
+        url: [host: host, port: port],
         secret_key_base: Keyword.get(config, :secret_key_base, @default_secret_key_base),
         live_view: [signing_salt: Keyword.get(config, :signing_salt, @default_signing_salt)],
         adapter: Keyword.get(config, :adapter, default_adapter()),


### PR DESCRIPTION
## Problem

When configuring LiveDebugger with a custom IP or `external_url`, the Phoenix startup log still shows:

```
[info] Access LiveDebugger.App.Web.Endpoint at http://localhost:4007
```

## Cause

`put_endpoint_config/1` sets `http: [ip: ..., port: ...]` but not `url: [host: ...]`. Phoenix uses the `url` config for the "Access at" log message, defaulting to `localhost`.

## Fix

Derive `host` from `external_url` if configured, otherwise use the IP string. Add `url: [host: host, port: port]` to endpoint config.

## Result

- Without `external_url`: `Access at http://127.0.0.11:4007`
- With `external_url: "http://my-host.local:4007"`: `Access at http://my-host.local:4007`

## Testing

Tested with Treehouse (dynamic per-branch IP allocation) - both IP fallback and external_url work correctly.