### PR TITLE
Fix MapSet assign summary updates

### DIFF
--- a/lib/live_debugger/app/utils/term_differ.ex
+++ b/lib/live_debugger/app/utils/term_differ.ex
@@ -100,7 +100,6 @@ defmodule LiveDebugger.App.Utils.TermDiffer do
     %Diff{
       type: :struct,
       ins: %{@primitive_key => struct2},
-      del: %{@primitive_key => struct1},
       diff: diff
     }
   end

--- a/lib/live_debugger/app/utils/term_differ.ex
+++ b/lib/live_debugger/app/utils/term_differ.ex
@@ -97,7 +97,12 @@ defmodule LiveDebugger.App.Utils.TermDiffer do
     map2 = Map.from_struct(struct2)
     {_, _, diff} = map_diffs(map1, map2)
 
-    %Diff{type: :struct, diff: diff}
+    %Diff{
+      type: :struct,
+      ins: %{@primitive_key => struct2},
+      del: %{@primitive_key => struct1},
+      diff: diff
+    }
   end
 
   def diff(struct1, struct2) when is_struct(struct1) and is_struct(struct2) do

--- a/lib/live_debugger/app/utils/term_parser.ex
+++ b/lib/live_debugger/app/utils/term_parser.ex
@@ -242,37 +242,30 @@ defmodule LiveDebugger.App.Utils.TermParser do
          %Diff{ins: %{@primitive_key => struct}},
          opts
        ) do
+     {content, expanded_before, expanded_after} = struct_display_elements(struct)
+
+    new_node =
+      TermNode.new(:struct, content,
+        expanded_before: expanded_before,
+        expanded_after: expanded_after
+      )
+
     new_node =
       case Keyword.get(opts, :key) do
         nil ->
-          {content, expanded_before, expanded_after} = struct_display_elements(struct)
-
-          TermNode.new(:struct, content,
-            expanded_before: expanded_before,
-            expanded_after: expanded_after
-          )
+          new_node
 
         key ->
           {key_span, sep_span} = key_prefix_and_separator(key)
-          {content, expanded_before, expanded_after} = struct_display_elements(struct)
 
-          summary =
-            TermNode.new(:struct, content,
-              expanded_before: expanded_before,
-              expanded_after: expanded_after
-            )
-
-          prefixed = TermNode.add_prefix(summary, [key_span, sep_span])
-          %TermNode{prefixed | key: key}
+          TermNode.add_prefix(new_node, [key_span, sep_span])
       end
 
     %TermNode{
       term_node
       | content: new_node.content,
         expanded_before: new_node.expanded_before,
-        expanded_after: new_node.expanded_after,
-        kind: new_node.kind,
-        key: new_node.key
+        expanded_after: new_node.expanded_after
     }
   end
 

--- a/lib/live_debugger/app/utils/term_parser.ex
+++ b/lib/live_debugger/app/utils/term_parser.ex
@@ -8,6 +8,8 @@ defmodule LiveDebugger.App.Utils.TermParser do
   alias LiveDebugger.App.Utils.TermNode.DisplayElement
   alias LiveDebugger.App.Utils.TermNode
 
+  @primitive_key TermDiffer.primitive_key()
+
   @doc """
   Convert term into infinite string which can be copied to IEx console.
   """
@@ -213,9 +215,7 @@ defmodule LiveDebugger.App.Utils.TermParser do
   end
 
   defp refresh_struct_content(%TermNode{} = term_node, %Diff{ins: ins}, opts) do
-    primitive_key = TermDiffer.primitive_key()
-
-    case Map.fetch(ins, primitive_key) do
+    case Map.fetch(ins, @primitive_key) do
       {:ok, struct} ->
         new_node =
           case Keyword.get(opts, :key) do

--- a/lib/live_debugger/app/utils/term_parser.ex
+++ b/lib/live_debugger/app/utils/term_parser.ex
@@ -214,33 +214,60 @@ defmodule LiveDebugger.App.Utils.TermParser do
     end
   end
 
-  defp refresh_struct_content(%TermNode{} = term_node, %Diff{ins: ins}, opts) do
-    case Map.fetch(ins, @primitive_key) do
-      {:ok, struct} ->
-        new_node =
-          case Keyword.get(opts, :key) do
-            nil ->
-              to_node(struct)
+  defp struct_summary_node(%module{} = struct) do
+    content =
+      if Inspect.impl_for(struct) in [Inspect.Any, Inspect.Phoenix.LiveView.Socket] do
+        [
+          DisplayElement.black("%"),
+          DisplayElement.blue(inspect(module)),
+          DisplayElement.black("{...}")
+        ]
+      else
+        [DisplayElement.black(inspect(struct))]
+      end
 
-            key ->
-              {key, struct}
-              |> to_key_value_node()
-              |> elem(1)
-          end
+    expanded_before = [
+      DisplayElement.black("%"),
+      DisplayElement.blue(inspect(module)),
+      DisplayElement.black("{")
+    ]
 
-        %TermNode{
-          term_node
-          | content: new_node.content,
-            expanded_before: new_node.expanded_before,
-            expanded_after: new_node.expanded_after,
-            kind: new_node.kind,
-            key: new_node.key
-        }
+    expanded_after = [DisplayElement.black("}")]
 
-      :error ->
-        term_node
-    end
+    TermNode.new(:struct, content,
+      expanded_before: expanded_before,
+      expanded_after: expanded_after
+    )
   end
+
+  defp refresh_struct_content(
+         %TermNode{} = term_node,
+         %Diff{ins: %{@primitive_key => struct}},
+         opts
+       ) do
+    new_node =
+      case Keyword.get(opts, :key) do
+        nil ->
+          struct_summary_node(struct)
+
+        key ->
+          {key_span, sep_span} = key_prefix_and_separator(key)
+          summary = struct_summary_node(struct)
+          prefixed = TermNode.add_prefix(summary, [key_span, sep_span])
+          %TermNode{prefixed | key: key}
+      end
+
+    %TermNode{
+      term_node
+      | content: new_node.content,
+        expanded_before: new_node.expanded_before,
+        expanded_after: new_node.expanded_after,
+        kind: new_node.kind,
+        key: new_node.key
+    }
+  end
+
+  defp refresh_struct_content(%TermNode{} = term_node, %Diff{}, _opts), do: term_node
 
   @spec index_term_node(TermNode.t()) :: TermNode.t()
   defp index_term_node(%TermNode{children: children} = term_node, id_path \\ "root") do
@@ -402,19 +429,22 @@ defmodule LiveDebugger.App.Utils.TermParser do
     TermNode.new(:other, [DisplayElement.black(inspect(other))])
   end
 
+  defp key_prefix_and_separator(key) do
+    case to_node(key) do
+      %TermNode{content: [%DisplayElement{text: ":" <> name} = span]} when is_atom(key) ->
+        {%{span | text: name <> ":"}, DisplayElement.black(" ")}
+
+      %TermNode{content: [span]} ->
+        {%{span | text: inspect(key, width: :infinity)}, DisplayElement.black(" => ")}
+
+      %TermNode{content: _content} ->
+        {%DisplayElement{text: inspect(key, width: :infinity), color: "text-code-1"},
+         DisplayElement.black(" => ")}
+    end
+  end
+
   defp to_key_value_node({key, value}) do
-    {key_span, sep_span} =
-      case to_node(key) do
-        %TermNode{content: [%DisplayElement{text: ":" <> name} = span]} when is_atom(key) ->
-          {%{span | text: name <> ":"}, DisplayElement.black(" ")}
-
-        %TermNode{content: [span]} ->
-          {%{span | text: inspect(key, width: :infinity)}, DisplayElement.black(" => ")}
-
-        %TermNode{content: _content} ->
-          {%DisplayElement{text: inspect(key, width: :infinity), color: "text-code-1"},
-           DisplayElement.black(" => ")}
-      end
+    {key_span, sep_span} = key_prefix_and_separator(key)
 
     node = value |> to_node() |> TermNode.add_prefix([key_span, sep_span])
 

--- a/lib/live_debugger/app/utils/term_parser.ex
+++ b/lib/live_debugger/app/utils/term_parser.ex
@@ -137,8 +137,10 @@ defmodule LiveDebugger.App.Utils.TermParser do
     |> TermNode.set_pulse(true, recursive: false)
   end
 
-  defp update_by_diff!(term_node, %Diff{type: :struct, diff: diff}, _opts) do
-    term_node_reduce_diff!(term_node, diff)
+  defp update_by_diff!(term_node, %Diff{type: :struct, diff: diff} = struct_diff, opts) do
+    term_node
+    |> refresh_struct_content(struct_diff, opts)
+    |> term_node_reduce_diff!(diff)
   end
 
   defp update_by_diff!(term_node, %Diff{type: :map, ins: ins, del: del, diff: diff}, _opts) do
@@ -207,6 +209,36 @@ defmodule LiveDebugger.App.Utils.TermParser do
       term_node
     else
       term_node |> TermNode.set_pulse(true, recursive: false)
+    end
+  end
+
+  defp refresh_struct_content(%TermNode{} = term_node, %Diff{ins: ins}, opts) do
+    primitive_key = TermDiffer.primitive_key()
+
+    case Map.fetch(ins, primitive_key) do
+      {:ok, struct} ->
+        new_node =
+          case Keyword.get(opts, :key) do
+            nil ->
+              to_node(struct)
+
+            key ->
+              {key, struct}
+              |> to_key_value_node()
+              |> elem(1)
+          end
+
+        %TermNode{
+          term_node
+          | content: new_node.content,
+            expanded_before: new_node.expanded_before,
+            expanded_after: new_node.expanded_after,
+            kind: new_node.kind,
+            key: new_node.key
+        }
+
+      :error ->
+        term_node
     end
   end
 

--- a/lib/live_debugger/app/utils/term_parser.ex
+++ b/lib/live_debugger/app/utils/term_parser.ex
@@ -214,7 +214,7 @@ defmodule LiveDebugger.App.Utils.TermParser do
     end
   end
 
-  defp struct_summary_node(%module{} = struct) do
+  defp struct_display_elements(%module{} = struct) do
     content =
       if Inspect.impl_for(struct) in [Inspect.Any, Inspect.Phoenix.LiveView.Socket] do
         [
@@ -234,10 +234,7 @@ defmodule LiveDebugger.App.Utils.TermParser do
 
     expanded_after = [DisplayElement.black("}")]
 
-    TermNode.new(:struct, content,
-      expanded_before: expanded_before,
-      expanded_after: expanded_after
-    )
+    {content, expanded_before, expanded_after}
   end
 
   defp refresh_struct_content(
@@ -248,11 +245,23 @@ defmodule LiveDebugger.App.Utils.TermParser do
     new_node =
       case Keyword.get(opts, :key) do
         nil ->
-          struct_summary_node(struct)
+          {content, expanded_before, expanded_after} = struct_display_elements(struct)
+
+          TermNode.new(:struct, content,
+            expanded_before: expanded_before,
+            expanded_after: expanded_after
+          )
 
         key ->
           {key_span, sep_span} = key_prefix_and_separator(key)
-          summary = struct_summary_node(struct)
+          {content, expanded_before, expanded_after} = struct_display_elements(struct)
+
+          summary =
+            TermNode.new(:struct, content,
+              expanded_before: expanded_before,
+              expanded_after: expanded_after
+            )
+
           prefixed = TermNode.add_prefix(summary, [key_span, sep_span])
           %TermNode{prefixed | key: key}
       end
@@ -377,34 +386,21 @@ defmodule LiveDebugger.App.Utils.TermParser do
     TermNode.new(:regex, [DisplayElement.black(inspect(regex))])
   end
 
-  defp to_node(%module{} = struct) when is_struct(struct) do
-    content =
-      if Inspect.impl_for(struct) in [Inspect.Any, Inspect.Phoenix.LiveView.Socket] do
-        [
-          DisplayElement.black("%"),
-          DisplayElement.blue(inspect(module)),
-          DisplayElement.black("{...}")
-        ]
-      else
-        [DisplayElement.black(inspect(struct))]
-      end
-
+  defp to_node(struct) when is_struct(struct) do
     children =
       struct
       |> Map.from_struct()
       |> Map.to_list()
       |> to_key_value_children()
 
+    {content, expanded_before, expanded_after} = struct_display_elements(struct)
+
     TermNode.new(
       :struct,
       content,
       children: children,
-      expanded_before: [
-        DisplayElement.black("%"),
-        DisplayElement.blue(inspect(module)),
-        DisplayElement.black("{")
-      ],
-      expanded_after: [DisplayElement.black("}")]
+      expanded_before: expanded_before,
+      expanded_after: expanded_after
     )
   end
 

--- a/lib/live_debugger/app/utils/term_parser.ex
+++ b/lib/live_debugger/app/utils/term_parser.ex
@@ -242,7 +242,7 @@ defmodule LiveDebugger.App.Utils.TermParser do
          %Diff{ins: %{@primitive_key => struct}},
          opts
        ) do
-     {content, expanded_before, expanded_after} = struct_display_elements(struct)
+    {content, expanded_before, expanded_after} = struct_display_elements(struct)
 
     new_node =
       TermNode.new(:struct, content,

--- a/test/app/utils/term_differ_test.exs
+++ b/test/app/utils/term_differ_test.exs
@@ -64,6 +64,8 @@ defmodule LiveDebugger.App.Utils.TermDifferTest do
       assert TermDiffer.diff(%TestStruct1{a: 1, b: 2, c: 4}, %TestStruct1{a: 1, b: 2, c: 5}) ==
                Fakes.term_diff(
                  type: :struct,
+                 ins: %{TermDiffer.primitive_key() => %TestStruct1{a: 1, b: 2, c: 5}},
+                 del: %{TermDiffer.primitive_key() => %TestStruct1{a: 1, b: 2, c: 4}},
                  diff: %{c: Fakes.term_diff_primitive(old_value: 4, new_value: 5)}
                )
     end

--- a/test/app/utils/term_differ_test.exs
+++ b/test/app/utils/term_differ_test.exs
@@ -65,7 +65,6 @@ defmodule LiveDebugger.App.Utils.TermDifferTest do
                Fakes.term_diff(
                  type: :struct,
                  ins: %{TermDiffer.primitive_key() => %TestStruct1{a: 1, b: 2, c: 5}},
-                 del: %{TermDiffer.primitive_key() => %TestStruct1{a: 1, b: 2, c: 4}},
                  diff: %{c: Fakes.term_diff_primitive(old_value: 4, new_value: 5)}
                )
     end

--- a/test/app/utils/term_parser_test.exs
+++ b/test/app/utils/term_parser_test.exs
@@ -748,6 +748,23 @@ defmodule LiveDebugger.App.Utils.TermParserTest do
              ]
     end
 
+    test "updates collapsed content when struct inspect output changes" do
+      old_term = %{message: MapSet.new([])}
+      new_term = %{message: MapSet.new(["0"])}
+
+      term_node = TermParser.term_to_display_tree(old_term)
+      diff = TermDiffer.diff(old_term, new_term)
+
+      assert {:ok, updated_node} = TermParser.update_by_diff(term_node, diff)
+      {_, message_node} = List.keyfind(updated_node.children, :message, 0)
+
+      assert Enum.map(message_node.content, & &1.text) == [
+               "message:",
+               " ",
+               "MapSet.new([\"0\"])"
+             ]
+    end
+
     test "handles map key additions and deletions" do
       old_term = %{"a" => 1, "b" => 2}
       new_term = %{"b" => 2, "d" => 4}

--- a/test/app/utils/term_parser_test.exs
+++ b/test/app/utils/term_parser_test.exs
@@ -12,6 +12,10 @@ defmodule LiveDebugger.App.Utils.TermParserTest do
     defstruct [:field1, :field2]
   end
 
+  defmodule NestedStruct do
+    defstruct [:inner, :stable]
+  end
+
   describe "term_to_display_tree/1" do
     test "parses a string term" do
       term = "Hello, World!"
@@ -748,21 +752,78 @@ defmodule LiveDebugger.App.Utils.TermParserTest do
              ]
     end
 
-    test "updates collapsed content when struct inspect output changes" do
-      old_term = %{message: MapSet.new([])}
-      new_term = %{message: MapSet.new(["0"])}
+    test "updates collapsed content for nested structs without touching stable siblings" do
+      old_term = %{
+        message: MapSet.new([]),
+        nested: %{
+          list: [MapSet.new([]), MapSet.new(["stable"])],
+          wrapper: %NestedStruct{
+            inner: %{set: MapSet.new([])},
+            stable: MapSet.new(["stable"])
+          }
+        },
+        untouched: %{value: "same"}
+      }
+
+      new_term = %{
+        message: MapSet.new(["0"]),
+        nested: %{
+          list: [MapSet.new(["list"]), MapSet.new(["stable"])],
+          wrapper: %NestedStruct{
+            inner: %{set: MapSet.new(["struct"])},
+            stable: MapSet.new(["stable"])
+          }
+        },
+        untouched: %{value: "same"}
+      }
 
       term_node = TermParser.term_to_display_tree(old_term)
       diff = TermDiffer.diff(old_term, new_term)
 
       assert {:ok, updated_node} = TermParser.update_by_diff(term_node, diff)
-      {_, message_node} = List.keyfind(updated_node.children, :message, 0)
+      message_node = child!(updated_node, :message)
 
       assert Enum.map(message_node.content, & &1.text) == [
                "message:",
                " ",
-               "MapSet.new([\"0\"])"
+               "MapSet.new([\"0\"])",
+               ","
              ]
+
+      nested_node = child!(updated_node, :nested)
+      list_node = child!(nested_node, :list)
+      changed_list_node = child!(list_node, 0)
+      stable_list_node = child!(list_node, 1)
+
+      assert changed_list_node.content |> Enum.map(& &1.text) |> List.first() ==
+               "MapSet.new([\"list\"])"
+
+      assert stable_list_node.content |> Enum.map(& &1.text) |> List.first() ==
+               "MapSet.new([\"stable\"])"
+
+      refute Enum.any?(stable_list_node.content, & &1.pulse?)
+
+      wrapper_node = child!(nested_node, :wrapper)
+      inner_node = child!(wrapper_node, :inner)
+      set_node = child!(inner_node, :set)
+      stable_struct_node = child!(wrapper_node, :stable)
+
+      assert Enum.map(set_node.content, & &1.text) == [
+               "set:",
+               " ",
+               "MapSet.new([\"struct\"])"
+             ]
+
+      assert stable_struct_node.content |> Enum.map(& &1.text) |> List.first() ==
+               "stable:"
+
+      refute Enum.any?(stable_struct_node.content, & &1.pulse?)
+
+      untouched_node = child!(updated_node, :untouched)
+      value_node = child!(untouched_node, :value)
+
+      assert Enum.map(value_node.content, & &1.text) == ["value:", " ", "\"same\""]
+      refute Enum.any?(value_node.content, & &1.pulse?)
     end
 
     test "handles map key additions and deletions" do
@@ -832,5 +893,10 @@ defmodule LiveDebugger.App.Utils.TermParserTest do
 
   defp close_term_node(%TermNode{} = term_node) do
     %TermNode{term_node | open?: false}
+  end
+
+  defp child!(%TermNode{children: children}, key) do
+    {^key, node} = List.keyfind(children, key, 0)
+    node
   end
 end


### PR DESCRIPTION
## Summary

- Carry the full updated struct through struct diffs so display nodes can refresh value-dependent collapsed content.
- Refresh struct display content while preserving existing child diffs and expanded state.
- Add a regression test for a `MapSet` assign whose collapsed summary changes after a diff update.

Fixes #986

## Validation

- `mix format --check-formatted lib/live_debugger/app/utils/term_differ.ex lib/live_debugger/app/utils/term_parser.ex test/app/utils/term_differ_test.exs test/app/utils/term_parser_test.exs`
- `mix test test/app/utils/term_differ_test.exs test/app/utils/term_parser_test.exs test/app/debugger/node_state/queries_test.exs test/app/debugger/node_state/web/components_test.exs`
- `mix test`