### PR TITLE
Fix recurring DETS "not properly closed" log from settings storage

### DIFF
--- a/lib/live_debugger/api/settings_storage.ex
+++ b/lib/live_debugger/api/settings_storage.ex
@@ -189,15 +189,14 @@ defmodule LiveDebugger.API.SettingsStorage do
     # platforms (notably on Windows it returns `{:error, :eexist}`), which would
     # make every `save/2` after the first one fail and silently stop persisting.
     # Remove the stale file and retry so persistence keeps working across saves.
+    #
+    # Note: the first `with` clause matches the *error* case on purpose, so any
+    # other result (including the happy-path `:ok`) is returned as-is. Do not add
+    # an `else` clause here or those results would be routed to it.
     defp rename_over(tmp, path) do
-      case File.rename(tmp, path) do
-        {:error, :eexist} ->
-          with :ok <- File.rm(path) do
-            File.rename(tmp, path)
-          end
-
-        other ->
-          other
+      with {:error, :eexist} <- File.rename(tmp, path),
+           :ok <- File.rm(path) do
+        File.rename(tmp, path)
       end
     end
 

--- a/lib/live_debugger/api/settings_storage.ex
+++ b/lib/live_debugger/api/settings_storage.ex
@@ -12,9 +12,13 @@ defmodule LiveDebugger.API.SettingsStorage do
   API for managing settings storage. In order to properly use invoke `init/0` at the start of application.
   Settings are kept in an ETS table for fast access and persisted to a file
   (inside `_build/*/live_debugger/`) so they survive application restarts.
-  Settings are retrieved in this order:
-  1. locally saved file (inside `_build/*/live_debugger/` directory)
-  2. default values
+  On `init/0` each setting value is resolved with the following precedence:
+  1. value set in the application config (`config :live_debugger, <setting>, ...`)
+  2. value persisted to the local file (inside `_build/*/live_debugger/` directory)
+  3. default value
+
+  Only values changed at runtime via `save/2` are persisted, so a value set in
+  config keeps taking precedence on every application start.
 
   Available settings are: `#{Enum.join(@available_settings, ", ")}`.
   """
@@ -172,12 +176,28 @@ defmodule LiveDebugger.API.SettingsStorage do
       tmp = path <> ".tmp." <> Integer.to_string(:erlang.unique_integer([:positive]))
 
       with :ok <- File.write(tmp, :erlang.term_to_binary(map)),
-           :ok <- File.rename(tmp, path) do
+           :ok <- rename_over(tmp, path) do
         :ok
       else
         {:error, reason} ->
           _ = File.rm(tmp)
           {:error, reason}
+      end
+    end
+
+    # `File.rename/2` does not overwrite an existing destination on all
+    # platforms (notably on Windows it returns `{:error, :eexist}`), which would
+    # make every `save/2` after the first one fail and silently stop persisting.
+    # Remove the stale file and retry so persistence keeps working across saves.
+    defp rename_over(tmp, path) do
+      case File.rename(tmp, path) do
+        {:error, :eexist} ->
+          with :ok <- File.rm(path) do
+            File.rename(tmp, path)
+          end
+
+        other ->
+          other
       end
     end
 

--- a/lib/live_debugger/api/settings_storage.ex
+++ b/lib/live_debugger/api/settings_storage.ex
@@ -10,7 +10,8 @@ defmodule LiveDebugger.API.SettingsStorage do
 
   @moduledoc """
   API for managing settings storage. In order to properly use invoke `init/0` at the start of application.
-  It uses Erlang's DETS (Disk Erlang Term Storage).
+  Settings are kept in an ETS table for fast access and persisted to a file
+  (inside `_build/*/live_debugger/`) so they survive application restarts.
   Settings are retrieved in this order:
   1. locally saved file (inside `_build/*/live_debugger/` directory)
   2. default values
@@ -24,7 +25,7 @@ defmodule LiveDebugger.API.SettingsStorage do
   @callback get_all() :: map()
 
   @doc """
-  Initializes dets table and read config values to fetch initial settings.
+  Initializes the settings table and reads config values to fetch initial settings.
   It should be called when application starts.
   """
   @spec init() :: :ok
@@ -89,67 +90,115 @@ defmodule LiveDebugger.API.SettingsStorage do
 
     @impl true
     def init() do
-      {:ok, _} =
-        :dets.open_file(@table_name,
-          auto_save: :timer.seconds(1),
-          file: file_path()
-        )
+      ensure_table!()
 
-      # On init we populate dets in the following order:
-      # 1. Check if user has set value in config, if so, we prioritize it
-      # 2. Otherwise, we check if value is saved in dets
-      # 3. If value is not saved in dets, we use default value
+      saved = load_saved()
+
+      # On init we resolve every setting in the following order:
+      # 1. value set in the application config, if any, is always prioritized
+      # 2. otherwise the value persisted from a previous session is used
+      # 3. otherwise the default value is used
       #
-      # This way when user specifies setting value in config, it will be always used on start.
-      # User still can change it in settings, and until next app restart it will be used.
+      # Only values explicitly changed at runtime via `save/2` are persisted,
+      # so a value set in config keeps winning on every application start.
       SettingsStorage.available_settings()
-      |> Enum.map(fn setting ->
-        {setting, Application.get_env(:live_debugger, setting, fetch_setting(setting))}
+      |> Enum.each(fn setting ->
+        value =
+          Application.get_env(
+            :live_debugger,
+            setting,
+            Map.get(saved, setting, @default_settings[setting])
+          )
+
+        :ets.insert(@table_name, {setting, value})
       end)
-      |> Enum.each(fn {setting, value} -> save(setting, value) end)
 
       :ok
     end
 
     @impl true
     def save(setting, value) do
-      :dets.insert(@table_name, {setting, value})
+      :ets.insert(@table_name, {setting, value})
+      persist()
     end
 
     @impl true
     def get(setting) do
-      fetch_setting(setting)
+      case table_lookup(setting) do
+        {:ok, value} -> value
+        :error -> @default_settings[setting]
+      end
     end
 
     @impl true
     def get_all() do
       SettingsStorage.available_settings()
-      |> Enum.map(fn setting ->
-        {setting, fetch_setting(setting)}
-      end)
+      |> Enum.map(fn setting -> {setting, get(setting)} end)
       |> Enum.into(%{})
     end
 
-    defp fetch_setting(setting) do
-      with {:error, :not_saved} <- get_from_dets(setting) do
-        @default_settings[setting]
+    defp ensure_table!() do
+      case :ets.whereis(@table_name) do
+        :undefined -> :ets.new(@table_name, [:set, :public, :named_table])
+        _ref -> @table_name
       end
     end
 
-    defp get_from_dets(setting) do
-      case :dets.lookup(@table_name, setting) do
-        [{^setting, value}] ->
-          value
+    defp table_lookup(setting) do
+      case :ets.whereis(@table_name) do
+        :undefined ->
+          :error
 
-        _ ->
-          {:error, :not_saved}
+        _ref ->
+          case :ets.lookup(@table_name, setting) do
+            [{^setting, value}] -> {:ok, value}
+            _ -> :error
+          end
       end
+    end
+
+    # Persists the whole settings table to a plain term file. A plain file has
+    # no "open/dirty" flag (unlike DETS), so an abrupt VM halt can never leave
+    # it in a state that triggers a repair on the next start.
+    defp persist() do
+      @table_name
+      |> :ets.tab2list()
+      |> Map.new()
+      |> write_file()
+    end
+
+    defp write_file(map) do
+      path = file_path()
+      tmp = path <> ".tmp." <> Integer.to_string(:erlang.unique_integer([:positive]))
+
+      with :ok <- File.write(tmp, :erlang.term_to_binary(map)),
+           :ok <- File.rename(tmp, path) do
+        :ok
+      else
+        {:error, reason} ->
+          _ = File.rm(tmp)
+          {:error, reason}
+      end
+    end
+
+    defp load_saved() do
+      case File.read(file_path()) do
+        {:ok, binary} -> decode(binary)
+        {:error, _reason} -> %{}
+      end
+    end
+
+    defp decode(binary) do
+      case :erlang.binary_to_term(binary, [:safe]) do
+        map when is_map(map) -> map
+        _ -> %{}
+      end
+    rescue
+      _ -> %{}
     end
 
     defp file_path() do
-      :live_debugger
-      |> Application.app_dir(@filename)
-      |> String.to_charlist()
+      Application.app_dir(:live_debugger, @filename)
     end
   end
 end

--- a/test/api/settings_storage_test.exs
+++ b/test/api/settings_storage_test.exs
@@ -1,0 +1,128 @@
+defmodule LiveDebugger.API.SettingsStorageTest do
+  # Not async: these tests exercise the real `Impl`, which relies on a shared
+  # named ETS table, a fixed persisted file and the application environment.
+  use ExUnit.Case, async: false
+
+  alias LiveDebugger.API.SettingsStorage
+  alias LiveDebugger.API.SettingsStorage.Impl
+
+  @table_name :lvdbg_settings
+  @filename "live_debugger_saved_settings"
+
+  setup do
+    settings = SettingsStorage.available_settings()
+
+    # Snapshot and restore the global state each test mutates so runs stay
+    # isolated (config values, the persisted file and the ETS table contents).
+    env_backup =
+      Map.new(settings, fn setting ->
+        {setting, Application.fetch_env(:live_debugger, setting)}
+      end)
+
+    file_backup = File.read(file_path())
+
+    Enum.each(settings, &Application.delete_env(:live_debugger, &1))
+    File.rm(file_path())
+
+    if :ets.whereis(@table_name) != :undefined do
+      :ets.delete_all_objects(@table_name)
+    end
+
+    on_exit(fn ->
+      Enum.each(env_backup, fn
+        {setting, {:ok, value}} -> Application.put_env(:live_debugger, setting, value)
+        {setting, :error} -> Application.delete_env(:live_debugger, setting)
+      end)
+
+      case file_backup do
+        {:ok, binary} -> File.write!(file_path(), binary)
+        {:error, _} -> File.rm(file_path())
+      end
+    end)
+
+    :ok
+  end
+
+  describe "init/0 value precedence" do
+    test "creates the settings table" do
+      assert :ok = Impl.init()
+
+      assert is_reference(:ets.whereis(@table_name))
+    end
+
+    test "uses default values when nothing is configured or saved" do
+      assert :ok = Impl.init()
+
+      assert Impl.get(:dead_view_mode) == true
+      assert Impl.get(:dead_liveviews) == false
+    end
+
+    test "prefers a saved value over the default" do
+      write_saved(%{dead_view_mode: :from_saved})
+
+      assert :ok = Impl.init()
+
+      assert Impl.get(:dead_view_mode) == :from_saved
+      # A setting missing from the saved file still falls back to its default.
+      assert Impl.get(:garbage_collection) == true
+    end
+
+    test "prefers a config value over both the saved value and the default" do
+      write_saved(%{dead_view_mode: :from_saved})
+      Application.put_env(:live_debugger, :dead_view_mode, :from_config)
+
+      assert :ok = Impl.init()
+
+      assert Impl.get(:dead_view_mode) == :from_config
+    end
+  end
+
+  describe "persistence across restarts" do
+    test "save/2 writes the setting to the persisted file" do
+      assert :ok = Impl.init()
+
+      assert :ok = Impl.save(:highlight_in_browser, false)
+
+      assert File.exists?(file_path())
+      assert read_saved()[:highlight_in_browser] == false
+    end
+
+    test "saved values are reloaded after a restart" do
+      assert :ok = Impl.init()
+      assert :ok = Impl.save(:dead_view_mode, false)
+
+      # Simulate a fresh VM: drop in-memory state but keep the persisted file.
+      :ets.delete_all_objects(@table_name)
+
+      assert :ok = Impl.init()
+
+      assert Impl.get(:dead_view_mode) == false
+      assert Impl.get(:garbage_collection) == true
+    end
+  end
+
+  describe "decoding of corrupt or legacy persisted data" do
+    test "falls back to defaults when the file is not a valid term (e.g. a leftover DETS file)" do
+      File.write!(file_path(), <<0, 1, 2, "not an erlang term", 255>>)
+
+      assert :ok = Impl.init()
+
+      assert Impl.get(:dead_view_mode) == true
+      assert Impl.get(:dead_liveviews) == false
+    end
+
+    test "falls back to defaults when the persisted term is not a map" do
+      File.write!(file_path(), :erlang.term_to_binary([1, 2, 3]))
+
+      assert :ok = Impl.init()
+
+      assert Impl.get(:garbage_collection) == true
+    end
+  end
+
+  defp file_path(), do: Application.app_dir(:live_debugger, @filename)
+
+  defp write_saved(map), do: File.write!(file_path(), :erlang.term_to_binary(map))
+
+  defp read_saved(), do: file_path() |> File.read!() |> :erlang.binary_to_term([:safe])
+end


### PR DESCRIPTION
Fixes #996.

Simply speaking, whenever I run `mix` multiple times on a freshly compiled project, I expect 'silence' each time, but I get this:

```
laptop my_project master  ? ❯ mix

laptop my_project master  ? ❯ mix
[info] dets: file ~c"/home/user/my_project/_build/dev/lib/live_debugger/live_debugger_saved_settings" not properly closed, repairing ...

laptop my_project master  ? ❯ 
```


## Problem
`SettingsStorage` opens a DETS table in `init/0` (via `LiveDebugger.start/2` → `get_children/0`) and never closes it. On VM exit the file is left in the "open" state, so the next `:dets.open_file/2` auto-repairs and logs `dets: file ... not properly closed, repairing ...` on nearly every start. Data is intact, but the log is noisy and recurring. Full details in #996.

## Why not just close on shutdown
`:dets.close/1` can't be added reliably via a shutdown hook:
- `mix run` / bare `mix` hard-halts the VM — no `terminate/2` or `Application.stop/1` runs.
- `:dets.close/1` may only be called by the process that opened the table (`{:error, :not_owner}` otherwise).

## Change
Back the settings with an ETS table (fast reads, same pattern as `TracesStorage` and `StatesStorage`) plus an atomically-written plain term file for persistence. A plain file has no open/dirty flag, so an abrupt halt can never trigger a repair.

- Public API, `@behaviour` callbacks, and `config > saved > default` precedence are unchanged.
- Only values changed at runtime via `save/2` are persisted, so a value set in config keeps winning on every boot.
- An old DETS file at the same path is ignored (decode failure → defaults) and superseded on the first `save/2`.

## Verification
- Bare `mix` 3×: no repair log.
- `save/2` writes the term file; a fresh VM boot reloads the saved value (persistence across restarts intact).
- Changed file compiles with no warnings.

Alternative considered: keep DETS and open/close per operation (smaller diff). Went with ETS + file to match the sibling storages and avoid per-read file I/O — happy to switch to the minimal DETS variant if you prefer.
