### PR TITLE
Docs: add privacy policy link to the footer

### DIFF
--- a/landing/src/components/ui/Footer.tsx
+++ b/landing/src/components/ui/Footer.tsx
@@ -151,7 +151,15 @@ const Footer = React.forwardRef<HTMLElement, FooterProps>(
                   ))}
                 </div>
                 <p className="text-md mt-3 font-normal">
-                  &copy; Software Mansion {new Date().getFullYear()}.
+                  &copy; Software Mansion {new Date().getFullYear()}. Read about
+                  our{" "}
+                  <a
+                    href="https://swmansion.com/privacy/policy/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Privacy Policy
+                  </a>
                 </p>
               </div>
             </div>


### PR DESCRIPTION
Added link to https://swmansion.com/privacy/policy/ at the bottom of the page
<img width="800" height="795" alt="image" src="https://github.com/user-attachments/assets/e8e1af6c-6545-4bac-b7ac-e6ebcd11e99c" />
